### PR TITLE
Fix: Apple Calendar sync cache not detecting new events

### DIFF
--- a/lich-plus/Core/Services/CalendarSyncService.swift
+++ b/lich-plus/Core/Services/CalendarSyncService.swift
@@ -152,7 +152,7 @@ final class CalendarSyncService: ObservableObject {
             }
 
             // Fetch all events from Apple Calendar with progress tracking
-            let remoteEvents = eventKitService.fetchAllEvents(from: enabledCalendars) { _ in
+            let remoteEvents = await eventKitService.fetchAllEvents(from: enabledCalendars) { _ in
                 // Progress handler - can be used for UI updates if needed
             }
 

--- a/lich-plusTests/CalendarSyncServiceTests.swift
+++ b/lich-plusTests/CalendarSyncServiceTests.swift
@@ -734,14 +734,14 @@ final class MockEventKitService: EventKitService {
         from startDate: Date,
         to endDate: Date,
         calendars: [EKCalendar]
-    ) -> [EKEvent] {
+    ) async -> [EKEvent] {
         mockEvents
     }
 
     override func fetchAllEvents(
         from calendars: [EKCalendar],
         progressHandler: ((Int) -> Void)? = nil
-    ) -> [EKEvent] {
+    ) async -> [EKEvent] {
         mockEvents
     }
 

--- a/lich-plusTests/EventKitServiceTests.swift
+++ b/lich-plusTests/EventKitServiceTests.swift
@@ -97,30 +97,30 @@ final class EventKitServiceTests: XCTestCase {
 
     // MARK: - Event Fetch Tests
 
-    func testFetchEventsInDateRangeReturnsArray() {
+    func testFetchEventsInDateRangeReturnsArray() async {
         let calendars = sut.fetchAllCalendars()
         let startDate = Date()
         let endDate = Calendar.current.date(byAdding: .day, value: 30, to: startDate)!
 
-        let events = sut.fetchEvents(from: startDate, to: endDate, calendars: calendars)
+        let events = await sut.fetchEvents(from: startDate, to: endDate, calendars: calendars)
         XCTAssertNotNil(events)
         XCTAssert(events is [EKEvent], "Should return array of EKEvent")
     }
 
-    func testFetchEventsEmptyCalendarArrayReturnsEmpty() {
+    func testFetchEventsEmptyCalendarArrayReturnsEmpty() async {
         let startDate = Date()
         let endDate = Calendar.current.date(byAdding: .day, value: 30, to: startDate)!
 
-        let events = sut.fetchEvents(from: startDate, to: endDate, calendars: [])
+        let events = await sut.fetchEvents(from: startDate, to: endDate, calendars: [])
         XCTAssertEqual(events.count, 0, "Empty calendar array should return no events")
     }
 
-    func testFetchEventsWithInvalidDateRangeReturnsEmpty() {
+    func testFetchEventsWithInvalidDateRangeReturnsEmpty() async {
         let calendars = sut.fetchAllCalendars()
         let endDate = Date()
         let startDate = Calendar.current.date(byAdding: .day, value: 30, to: endDate)! // startDate after endDate
 
-        let events = sut.fetchEvents(from: startDate, to: endDate, calendars: calendars)
+        let events = await sut.fetchEvents(from: startDate, to: endDate, calendars: calendars)
         XCTAssertEqual(events.count, 0, "Invalid date range should return no events")
     }
 
@@ -493,7 +493,7 @@ final class EventKitServiceTests: XCTestCase {
         }
     }
 
-    func testFetchEventsDateOrdering() {
+    func testFetchEventsDateOrdering() async {
         let calendars = sut.fetchAllCalendars()
         guard !calendars.isEmpty else {
             XCTSkip("No calendars available for testing")
@@ -503,7 +503,7 @@ final class EventKitServiceTests: XCTestCase {
         let startDate = Calendar.current.date(byAdding: .day, value: -30, to: Date())!
         let endDate = Calendar.current.date(byAdding: .day, value: 30, to: Date())!
 
-        let events = sut.fetchEvents(from: startDate, to: endDate, calendars: calendars)
+        let events = await sut.fetchEvents(from: startDate, to: endDate, calendars: calendars)
 
         // Verify all events are within the date range
         for event in events {

--- a/lich-plusTests/InfinitePageViewTests.swift
+++ b/lich-plusTests/InfinitePageViewTests.swift
@@ -430,8 +430,8 @@ final class InfinitePageViewTests: XCTestCase {
         // Given
         var currentController = coordinator.makeHostingController(for: 0)
 
-        // When & Then - iterate multiple times
-        for expectedIndex in (-1)...(-100) {
+        // When & Then - iterate multiple times (use stride for descending sequence)
+        for expectedIndex in stride(from: -1, through: -100, by: -1) {
             let prevController = coordinator.pageViewController(
                 UIPageViewController(),
                 viewControllerBefore: currentController


### PR DESCRIPTION
## Summary
- Fix Apple Calendar sync not detecting new events added after initial sync
- Fix test crash in InfinitePageViewTests

## Problem
When syncing with Apple Calendar, the first sync works correctly and imports all events. However, subsequent syncs fail to pick up new events that were added in the Apple Calendar app after the initial sync.

**Root Cause:** The `EKEventStore` caches data internally. When new events are added in Apple Calendar after the app initializes, the store doesn't automatically refresh its internal cache.

## Solution
Added `eventStore.refreshSourcesIfNecessary()` calls at the start of both `fetchEvents()` and `fetchAllEvents()` methods in `EventKitService.swift`. This is Apple's recommended approach for refreshing the EventKit cache when external changes may have occurred.

## Changes
- `lich-plus/Core/Services/EventKitService.swift`: Added cache refresh before fetching events
- `lich-plusTests/InfinitePageViewTests.swift`: Fixed invalid range iteration that caused test crash

## Test plan
- [x] Build passes
- [x] All unit tests pass
- [ ] Manual test: Add event in Apple Calendar, sync in app, verify new event appears
- [ ] Manual test: Modify event in Apple Calendar, sync in app, verify changes appear