### PR TITLE
feat: add complete English and Vietnamese translations

### DIFF
--- a/lich-plus/Localizable.xcstrings
+++ b/lich-plus/Localizable.xcstrings
@@ -63,7 +63,21 @@
       }
     },
     "12 Trực" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "12 Zodiac Officers"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "12 Trực"
+          }
+        }
+      }
     },
     "About" : {
       "extractionState" : "manual",
@@ -83,16 +97,72 @@
       }
     },
     "Account" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Account"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tài khoản"
+          }
+        }
+      }
     },
     "Add an ICS calendar URL to get started" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add an ICS calendar URL to get started"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thêm URL lịch ICS để bắt đầu"
+          }
+        }
+      }
     },
     "Add Calendar" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Calendar"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thêm lịch"
+          }
+        }
+      }
     },
     "Add ICS Calendar" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add ICS Calendar"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thêm lịch ICS"
+          }
+        }
+      }
     },
     "Add new item" : {
 
@@ -302,7 +372,21 @@
       }
     },
     "Âm lịch" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lunar Calendar"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Âm lịch"
+          }
+        }
+      }
     },
     "Âm lịch:" : {
       "extractionState" : "manual",
@@ -356,7 +440,21 @@
       }
     },
     "Available Calendars" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Available Calendars"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lịch có sẵn"
+          }
+        }
+      }
     },
     "Background Sync" : {
       "extractionState" : "manual",
@@ -410,7 +508,21 @@
       }
     },
     "Calendar Name" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Calendar Name"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tên lịch"
+          }
+        }
+      }
     },
     "Calendar Sync" : {
       "extractionState" : "manual",
@@ -430,7 +542,21 @@
       }
     },
     "Calendar URL" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Calendar URL"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL lịch"
+          }
+        }
+      }
     },
     "calendar_selected" : {
       "extractionState" : "manual",
@@ -484,7 +610,21 @@
       }
     },
     "Calendars" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Calendars"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lịch"
+          }
+        }
+      }
     },
     "Calendars to Sync" : {
       "extractionState" : "manual",
@@ -521,7 +661,21 @@
       }
     },
     "Cancel" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hủy"
+          }
+        }
+      }
     },
     "category.birthday" : {
       "extractionState" : "manual",
@@ -660,25 +814,123 @@
       }
     },
     "Choose which Google calendars to display in this app." : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose which Google calendars to display in this app."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chọn lịch Google nào để hiển thị trong ứng dụng này."
+          }
+        }
+      }
     },
     "Choose which Outlook calendars to display in this app." : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose which Outlook calendars to display in this app."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chọn lịch Outlook nào để hiển thị trong ứng dụng này."
+          }
+        }
+      }
     },
     "Clear search" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear search"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xóa tìm kiếm"
+          }
+        }
+      }
     },
     "Connect with Google" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connect with Google"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kết nối với Google"
+          }
+        }
+      }
     },
     "Connect your Google account to sync your Google Calendar events with this app." : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connect your Google account to sync your Google Calendar events with this app."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kết nối tài khoản Google của bạn để đồng bộ sự kiện Google Calendar với ứng dụng này."
+          }
+        }
+      }
     },
     "Connect your Microsoft account to sync your Outlook calendar events with this app." : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connect your Microsoft account to sync your Outlook calendar events with this app."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kết nối tài khoản Microsoft của bạn để đồng bộ sự kiện Outlook với ứng dụng này."
+          }
+        }
+      }
     },
     "Connected" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connected"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đã kết nối"
+          }
+        }
+      }
     },
     "createItem.allDay" : {
       "extractionState" : "manual",
@@ -1259,11 +1511,18 @@
       }
     },
     "date.lunarFormat %lld %lld %@" : {
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "date.lunarFormat %1$lld %2$lld %3$@"
+            "state" : "translated",
+            "value" : "Day %1$lld month %2$lld year %3$@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ngày %1$lld tháng %2$lld năm %3$@"
           }
         }
       }
@@ -1456,19 +1715,89 @@
       }
     },
     "Delete" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xóa"
+          }
+        }
+      }
     },
     "Disconnect Google Account" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect Google Account"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ngắt kết nối tài khoản Google"
+          }
+        }
+      }
     },
     "Disconnect Microsoft Account" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnect Microsoft Account"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ngắt kết nối tài khoản Microsoft"
+          }
+        }
+      }
     },
     "Done" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Done"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xong"
+          }
+        }
+      }
     },
     "Dương lịch" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solar Calendar"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dương lịch"
+          }
+        }
+      }
     },
     "Dương lịch:" : {
       "extractionState" : "manual",
@@ -1488,7 +1817,21 @@
       }
     },
     "Edit" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sửa"
+          }
+        }
+      }
     },
     "empty.addButton" : {
       "extractionState" : "manual",
@@ -1508,13 +1851,55 @@
       }
     },
     "Enable the calendars you want to display in this app. Changes are saved automatically." : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable the calendars you want to display in this app. Changes are saved automatically."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bật các lịch bạn muốn hiển thị trong ứng dụng này. Các thay đổi được lưu tự động."
+          }
+        }
+      }
     },
     "Error" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lỗi"
+          }
+        }
+      }
     },
     "Event not found" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Event not found"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không tìm thấy sự kiện"
+          }
+        }
+      }
     },
     "event.addNew" : {
       "extractionState" : "manual",
@@ -1602,10 +1987,38 @@
       }
     },
     "Google Calendar" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Google Calendar"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Google Calendar"
+          }
+        }
+      }
     },
     "Google Calendars" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Google Calendars"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lịch Google"
+          }
+        }
+      }
     },
     "Grant Access" : {
       "extractionState" : "manual",
@@ -1676,10 +2089,38 @@
       }
     },
     "ICS Calendar" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ICS Calendar"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lịch ICS"
+          }
+        }
+      }
     },
     "ICS Calendar subscriptions are read-only. Events are automatically synced with your calendar app." : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ICS Calendar subscriptions are read-only. Events are automatically synced with your calendar app."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đăng ký lịch ICS chỉ đọc. Sự kiện được tự động đồng bộ với ứng dụng lịch của bạn."
+          }
+        }
+      }
     },
     "Import from Apple Calendar" : {
       "extractionState" : "manual",
@@ -1699,7 +2140,21 @@
       }
     },
     "Information" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Information"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thông tin"
+          }
+        }
+      }
     },
     "Intelligent calendar and task recommendations" : {
       "extractionState" : "manual",
@@ -1787,16 +2242,72 @@
       }
     },
     "Last sync: %@" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Last sync: %@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đồng bộ lần cuối: %@"
+          }
+        }
+      }
     },
     "Last synced" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Last synced"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đồng bộ lần cuối"
+          }
+        }
+      }
     },
     "Last synced: %@" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Last synced: %@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đồng bộ lần cuối: %@"
+          }
+        }
+      }
     },
     "Loading..." : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading..."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đang tải..."
+          }
+        }
+      }
     },
     "lunar.month.1" : {
       "extractionState" : "manual",
@@ -2003,10 +2514,38 @@
       }
     },
     "Mark Complete" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mark Complete"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đánh dấu hoàn thành"
+          }
+        }
+      }
     },
     "Mark Incomplete" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mark Incomplete"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đánh dấu chưa hoàn thành"
+          }
+        }
+      }
     },
     "Màu may mắn" : {
       "extractionState" : "manual",
@@ -2026,10 +2565,38 @@
       }
     },
     "No Calendar Subscriptions" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Calendar Subscriptions"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không có đăng ký lịch"
+          }
+        }
+      }
     },
     "No calendars found" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No calendars found"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không tìm thấy lịch"
+          }
+        }
+      }
     },
     "No Calendars Found" : {
       "extractionState" : "manual",
@@ -2083,97 +2650,539 @@
       }
     },
     "Not connected" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not connected"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chưa kết nối"
+          }
+        }
+      }
     },
     "notification.cancel" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hủy"
+          }
+        }
+      }
     },
     "notification.daysBefore" : {
-      "comment" : "Days before event"
+      "comment" : "Days before event",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld days before"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trước %lld ngày"
+          }
+        }
+      }
     },
     "notification.defaultReminder" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Default Reminder"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nhắc nhở mặc định"
+          }
+        }
+      }
     },
     "notification.enable" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable Notifications"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bật thông báo"
+          }
+        }
+      }
     },
     "notification.event.startsIn" : {
-      "comment" : "Event notification body"
+      "comment" : "Event notification body",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Event starts in %@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sự kiện bắt đầu trong %@"
+          }
+        }
+      }
     },
     "notification.events.enable" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable Event Notifications"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bật thông báo sự kiện"
+          }
+        }
+      }
     },
     "notification.events.section" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Event Reminders"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nhắc nhở sự kiện"
+          }
+        }
+      }
     },
     "notification.fixed.enable" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable Holiday Reminders"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bật nhắc ngày lễ"
+          }
+        }
+      }
     },
     "notification.fixed.reminderDays" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remind Days Before"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nhắc trước số ngày"
+          }
+        }
+      }
     },
     "notification.fixed.section" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Holiday Reminders"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nhắc ngày lễ"
+          }
+        }
+      }
     },
     "notification.holiday.inDays" : {
-      "comment" : "Holiday reminder body"
+      "comment" : "Holiday reminder body",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ is in %lld days"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ còn %lld ngày nữa"
+          }
+        }
+      }
     },
     "notification.minutesBefore" : {
-      "comment" : "Minutes before event"
+      "comment" : "Minutes before event",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld minutes before"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trước %lld phút"
+          }
+        }
+      }
     },
     "notification.mung1.body" : {
-      "comment" : "Mùng 1 notification body"
+      "comment" : "Mùng 1 notification body",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Today is the 1st of the lunar month"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hôm nay là ngày Mùng 1 âm lịch"
+          }
+        }
+      }
     },
     "notification.mung1.enable" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remind on New Moon"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nhắc vào ngày Mùng 1"
+          }
+        }
+      }
     },
     "notification.mung1.section" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New Moon (Mùng 1)"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ngày Mùng 1"
+          }
+        }
+      }
     },
     "notification.mung1.title" : {
-      "comment" : "Mùng 1 notification title"
+      "comment" : "Mùng 1 notification title",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New Moon Today"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hôm nay là ngày Mùng 1"
+          }
+        }
+      }
     },
     "notification.onDay" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "On the day"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trong ngày"
+          }
+        }
+      }
     },
     "notification.openSettings" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Settings"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mở Cài đặt"
+          }
+        }
+      }
     },
     "notification.permissionDenied.footer" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You previously denied notification permission."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bạn đã từ chối quyền thông báo trước đó."
+          }
+        }
+      }
     },
     "notification.permissionRequired.message" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please enable notifications in Settings to receive reminders."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vui lòng bật thông báo trong Cài đặt để nhận nhắc nhở."
+          }
+        }
+      }
     },
     "notification.permissionRequired.title" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permission Required"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cần quyền truy cập"
+          }
+        }
+      }
     },
     "notification.ram.body" : {
-      "comment" : "Rằm notification body"
+      "comment" : "Rằm notification body",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Today is the 15th of the lunar month"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hôm nay là ngày 15 âm lịch"
+          }
+        }
+      }
     },
     "notification.ram.enable" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remind on Full Moon"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nhắc vào ngày Rằm"
+          }
+        }
+      }
     },
     "notification.ram.section" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Full Moon (Rằm)"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ngày Rằm"
+          }
+        }
+      }
     },
     "notification.ram.title" : {
-      "comment" : "Rằm notification title"
+      "comment" : "Rằm notification title",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Full Moon Today"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hôm nay là ngày Rằm"
+          }
+        }
+      }
     },
     "notification.settings.subtitle" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configure notification preferences"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cấu hình tùy chọn thông báo"
+          }
+        }
+      }
     },
     "notification.settings.title" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notifications"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thông báo"
+          }
+        }
+      }
     },
     "notification.time" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notification Time"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giờ thông báo"
+          }
+        }
+      }
     },
     "Now" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Now"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bây giờ"
+          }
+        }
+      }
     },
     "OK" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        }
+      }
     },
     "Open Settings" : {
       "extractionState" : "manual",
@@ -2193,10 +3202,38 @@
       }
     },
     "Outlook Calendar" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Outlook Calendar"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Outlook Calendar"
+          }
+        }
+      }
     },
     "Outlook Calendars" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Outlook Calendars"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lịch Outlook"
+          }
+        }
+      }
     },
     "priority.high" : {
       "extractionState" : "manual",
@@ -2420,7 +3457,21 @@
       }
     },
     "Refresh Calendars" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Refresh Calendars"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Làm mới lịch"
+          }
+        }
+      }
     },
     "reminder.1hr" : {
       "extractionState" : "manual",
@@ -2494,7 +3545,21 @@
 
     },
     "Search" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tìm kiếm"
+          }
+        }
+      }
     },
     "search.mode" : {
       "extractionState" : "manual",
@@ -2633,19 +3698,89 @@
       }
     },
     "Sign in with Microsoft" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign in with Microsoft"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đăng nhập với Microsoft"
+          }
+        }
+      }
     },
     "Signed in as" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Signed in as"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đã đăng nhập với"
+          }
+        }
+      }
     },
     "Signing in..." : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Signing in..."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đang đăng nhập..."
+          }
+        }
+      }
     },
     "Status" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Status"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trạng thái"
+          }
+        }
+      }
     },
     "Sự kiện" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Event"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sự kiện"
+          }
+        }
+      }
     },
     "Sự kiện hôm nay" : {
       "extractionState" : "manual",
@@ -2665,10 +3800,38 @@
       }
     },
     "Subscribe to calendars" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Subscribe to calendars"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đăng ký lịch"
+          }
+        }
+      }
     },
     "Supported URL formats:" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supported URL formats:"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Định dạng URL được hỗ trợ:"
+          }
+        }
+      }
     },
     "Sync" : {
       "extractionState" : "manual",
@@ -2756,10 +3919,38 @@
       }
     },
     "Synced" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Synced"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đã đồng bộ"
+          }
+        }
+      }
     },
     "Syncing..." : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Syncing..."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đang đồng bộ..."
+          }
+        }
+      }
     },
     "tab.calendar" : {
       "extractionState" : "manual",
@@ -2830,10 +4021,38 @@
       }
     },
     "Tap the refresh button to fetch your Google calendars." : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap the refresh button to fetch your Google calendars."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nhấn nút làm mới để tải lịch Google của bạn."
+          }
+        }
+      }
     },
     "Tap the refresh button to fetch your Outlook calendars." : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap the refresh button to fetch your Outlook calendars."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nhấn nút làm mới để tải lịch Outlook của bạn."
+          }
+        }
+      }
     },
     "task.add" : {
       "extractionState" : "manual",
@@ -3295,7 +4514,21 @@
       }
     },
     "task.today" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Today"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hôm nay"
+          }
+        }
+      }
     },
     "task.tomorrow" : {
       "extractionState" : "manual",
@@ -3332,10 +4565,38 @@
       }
     },
     "This will remove all synced Google Calendar events from this app." : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This will remove all synced Google Calendar events from this app."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thao tác này sẽ xóa tất cả sự kiện Google Calendar đã đồng bộ khỏi ứng dụng."
+          }
+        }
+      }
     },
     "This will remove all synced Outlook calendar events from this app." : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This will remove all synced Outlook calendar events from this app."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thao tác này sẽ xóa tất cả sự kiện Outlook đã đồng bộ khỏi ứng dụng."
+          }
+        }
+      }
     },
     "Thông tin may mắn" : {
       "extractionState" : "manual",
@@ -3355,10 +4616,38 @@
       }
     },
     "timeline.allDay" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All Day"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cả ngày"
+          }
+        }
+      }
     },
     "timeline.noAllDayEvents" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No all-day events"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không có sự kiện cả ngày"
+          }
+        }
+      }
     },
     "timeline.search" : {
       "extractionState" : "manual",
@@ -3507,13 +4796,55 @@
       }
     },
     "Việc nên tránh" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activities to Avoid"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Việc nên tránh"
+          }
+        }
+      }
     },
     "You don't have any calendars available for syncing." : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You don't have any calendars available for syncing."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bạn không có lịch nào để đồng bộ."
+          }
+        }
+      }
     },
     "You previously denied calendar access. Please enable it in Settings." : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You previously denied calendar access. Please enable it in Settings."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bạn đã từ chối quyền truy cập lịch. Vui lòng bật trong Cài đặt."
+          }
+        }
+      }
     }
   },
   "version" : "1.1"


### PR DESCRIPTION
## Summary
- Added 92 missing translations to `Localizable.xcstrings` for comprehensive English and Vietnamese localization
- All Vietnamese translations use proper Unicode diacritics (ă, â, đ, ê, ô, ơ, ư) instead of ASCII approximations
- Fixed format string for lunar date display to support proper positional arguments

## Changes
This PR adds translations for the following categories:
- **General UI** (12 strings): Account, Cancel, Delete, Done, Edit, Error, Information, Loading, Now, OK, Search, Status
- **Calendar Sync** (13 strings): Calendar management and subscription UI
- **Google/Microsoft Integration** (14 strings): OAuth connection and calendar selection
- **Status Messages** (10 strings): Connection states, sync status, last sync timestamps
- **ICS Calendar, Permissions, Tasks** (7 strings): ICS subscriptions, calendar permissions, task actions
- **Notification Settings** (28 strings): Comprehensive notification preferences including Rằm, Mùng 1, holidays, and event reminders
- **Timeline & Vietnamese Terms** (7 strings): Timeline UI and Vietnamese-specific astronomical terms (12 Trực, Âm lịch, Dương lịch, etc.)
- **Format String Fix** (1 string): Corrected `date.lunarFormat` to use positional arguments

## Technical Details
- All entries follow the manual extraction pattern: `extractionState: "manual"` and `state: "translated"`
- Brand names (Google Calendar, Outlook Calendar, Microsoft) remain unchanged
- Format strings use proper positional arguments for language-specific word order (e.g., `%1$lld %2$lld %3$@`)

## Test Plan
- [ ] Build the app successfully with updated string catalog
- [ ] Verify English translations display correctly in UI
- [ ] Verify Vietnamese translations display correctly with proper diacritics
- [ ] Test notification settings UI shows translated strings
- [ ] Test calendar sync UI shows translated strings
- [ ] Verify lunar date format displays correctly in both languages
- [ ] Run unit tests to ensure no regressions