### PR TITLE
chore: add en-GB App Store metadata for UK localization

### DIFF
--- a/fastlane/metadata/en-GB/description.txt
+++ b/fastlane/metadata/en-GB/description.txt
@@ -1,0 +1,39 @@
+Lich+ is a modern Vietnamese calendar app that seamlessly combines lunar and solar calendars with task and event management in a beautiful, easy-to-use interface.
+
+ACCURATE LUNAR-SOLAR CALENDAR
+- View lunar and solar dates side by side
+- Display traditional Can Chi (Heavenly Stems and Earthly Branches)
+- 12 Truc system and Hoang Dao (auspicious days) information
+- Traditional feng shui day quality ratings
+- Perpetual calendar support from 1900-2100
+
+SMART EVENT MANAGEMENT
+- Create events based on lunar or solar calendar
+- Recurring events following lunar cycles (lunar birthdays, anniversaries)
+- Sync with Apple Calendar, Google Calendar, Microsoft Calendar
+- Smart reminders for important events
+- Colour-coded event categories
+
+EFFICIENT TASK MANAGEMENT
+- Visual task timeline
+- Filter by day, week, or month
+- Quick search for tasks and events
+- Easy completion tracking
+
+MODERN DESIGN
+- Clean, minimalist interface
+- Smooth user experience
+- Full Vietnamese language support
+- Optimised for iOS 17+
+
+KEY FEATURES
+- Quick day info preview on monthly calendar
+- Infinite scrolling between months
+- Apple Calendar-style month picker
+- Home screen widgets (coming soon)
+
+Lich+ is designed specifically for Vietnamese users, helping you never miss important lunar dates like Tet (Lunar New Year), Mid-Autumn Festival, ancestral death anniversaries, and lunar birthdays of loved ones.
+
+Perfect for Vietnamese diaspora who want to stay connected with traditional Vietnamese calendar and customs.
+
+Download Lich+ now to experience smart time management the Vietnamese way!

--- a/fastlane/metadata/en-GB/keywords.txt
+++ b/fastlane/metadata/en-GB/keywords.txt
@@ -1,0 +1,1 @@
+vietnamese calendar,lunar calendar,lich viet,asian calendar,task manager,event planner,tet,reminder

--- a/fastlane/metadata/en-GB/name.txt
+++ b/fastlane/metadata/en-GB/name.txt
@@ -1,0 +1,1 @@
+Lich+ Vietnamese Calendar

--- a/fastlane/metadata/en-GB/promotional_text.txt
+++ b/fastlane/metadata/en-GB/promotional_text.txt
@@ -1,0 +1,1 @@
+Get ready for Tet 2026! View lunar calendar, find auspicious days, and manage events easily with Lich+ - the modern Vietnamese calendar app.

--- a/fastlane/metadata/en-GB/release_notes.txt
+++ b/fastlane/metadata/en-GB/release_notes.txt
@@ -1,0 +1,11 @@
+Welcome to Lich+ - The next generation Vietnamese calendar app!
+
+First release includes:
+- Monthly calendar with lunar-solar display
+- Day quality info, 12 Truc system, Hoang Dao
+- Event management with lunar recurrence support
+- Task management with visual timeline
+- Apple Calendar sync
+- Beautiful, easy-to-use interface
+
+Wishing you a prosperous Year of the Horse 2026!

--- a/fastlane/metadata/en-GB/subtitle.txt
+++ b/fastlane/metadata/en-GB/subtitle.txt
@@ -1,0 +1,1 @@
+Lunar Calendar & Task Manager


### PR DESCRIPTION
## Summary
- Add English (UK) App Store metadata files for Fastlane

## Files Added
- `fastlane/metadata/en-GB/description.txt`
- `fastlane/metadata/en-GB/keywords.txt`
- `fastlane/metadata/en-GB/name.txt`
- `fastlane/metadata/en-GB/promotional_text.txt`
- `fastlane/metadata/en-GB/release_notes.txt`
- `fastlane/metadata/en-GB/subtitle.txt`

## Test plan
- [ ] Verify metadata uploads correctly via `fastlane deliver`