### PR TITLE
fix(calendar): repair lunar off-by-one near new-moon (29/2 → 1/3/2026)

### DIFF
--- a/lich-plus/Features/Calendar/Models/LunarCalendar.swift
+++ b/lich-plus/Features/Calendar/Models/LunarCalendar.swift
@@ -67,7 +67,76 @@ struct LunarCalendar {
             libraryChi: lunarDate.chi
         )
 
-        return (day: lunarDate.day, month: lunarDate.month, year: year)
+        let raw = (day: lunarDate.day, month: lunarDate.month, year: year)
+
+        // The underlying pod (VietnameseLunar / Hồ Ngọc Đức algorithm) has a
+        // floor-rounding artifact near GMT+7-midnight new-moon boundaries that
+        // produces off-by-one lunar days for certain solar dates (e.g.
+        // 2026-04-16). Apply hard overrides for known cases, then a generic
+        // repair pass.
+        if let override = lunarOverride(for: date) {
+            return override
+        }
+        return repairOffByOneIfNeeded(date: date, raw: raw)
+    }
+
+    /// Known off-by-one dates returned by the VietnameseLunar pod. Keyed by
+    /// "YYYY-M-D" (no zero padding) interpreted in Asia/Ho_Chi_Minh.
+    private static let lunarOverrides: [String: (day: Int, month: Int, year: Int)] = [
+        "2026-4-16": (29, 2, 2026)
+    ]
+
+    private static func lunarOverride(for date: Date) -> (day: Int, month: Int, year: Int)? {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "Asia/Ho_Chi_Minh") ?? .current
+        let comps = cal.dateComponents([.year, .month, .day], from: date)
+        guard let y = comps.year, let m = comps.month, let d = comps.day else { return nil }
+        return lunarOverrides["\(y)-\(m)-\(d)"]
+    }
+
+    /// Detect and repair the pod's off-by-one where two consecutive solar days
+    /// return the same lunar (day, month) tuple. A correct lunar calendar can
+    /// never produce that, so we treat it as a fingerprint of the bug.
+    ///
+    /// In the observed case (Apr 2026): pod returns 28/2, 1/3, 1/3, 2/3 for
+    /// solar Apr 15–18, skipping 29/2. The DUPLICATE pair is (Apr 16, Apr 17)
+    /// and the BUGGY day is the EARLIER one (Apr 16). So we look FORWARD: if
+    /// pod(date) == pod(date+1), then `date` is the off-by-one and the
+    /// correct lunar day is pod(date-1).day + 1.
+    private static func repairOffByOneIfNeeded(
+        date: Date,
+        raw: (day: Int, month: Int, year: Int)
+    ) -> (day: Int, month: Int, year: Int) {
+        // Fast path: this bug class always manifests as the pod returning day=1
+        // one solar day too early (then repeating it on the legitimate day-1
+        // solar). If raw.day != 1, this date cannot be the duplicate-pair's
+        // earlier (buggy) member, so skip the extra pod calls.
+        guard raw.day == 1 else { return raw }
+
+        let cal = Calendar(identifier: .gregorian)
+        guard let nextSolar = cal.date(byAdding: .day, value: 1, to: date),
+              let next = VietnameseCalendar(date: nextSolar).vietnameseDate
+        else { return raw }
+
+        // Only the duplicate-with-next pattern indicates `date` is the buggy one.
+        guard next.day == raw.day && next.month == raw.month else {
+            return raw
+        }
+
+        guard let prevSolar = cal.date(byAdding: .day, value: -1, to: date),
+              let prev = VietnameseCalendar(date: prevSolar).vietnameseDate
+        else { return raw }
+
+        let candidate = prev.day + 1
+        // Lunar months are 29 or 30 days. If incrementing would overflow,
+        // bail out conservatively and trust the pod's raw value (the override
+        // table can catch any cross-month edge case).
+        guard candidate <= 30 else { return raw }
+
+        // Use the prior day's (month, year) — they should already match `raw`'s
+        // month in this duplicate-pair case, but anchoring on `prev` avoids
+        // any year-boundary pitfall.
+        return (day: candidate, month: prev.month, year: raw.year)
     }
 
     private static func resolveLunarYear(solarYear: Int, libraryCan: String, libraryChi: String) -> Int {

--- a/lich-plus/Features/Calendar/Models/LunarCalendar.swift
+++ b/lich-plus/Features/Calendar/Models/LunarCalendar.swift
@@ -91,10 +91,17 @@ struct LunarCalendar {
         "2026-4-16": (29, 2, 2026)
     ]
 
-    private static func lunarOverride(for date: Date) -> (day: Int, month: Int, year: Int)? {
+    /// Shared Asia/Ho_Chi_Minh Gregorian calendar. The wrapper layer must
+    /// resolve solar Y/M/D and shift by ±1 day in Vietnam time, otherwise a
+    /// device in another timezone could land on the wrong solar year/day.
+    private static let hcmCalendar: Calendar = {
         var cal = Calendar(identifier: .gregorian)
         cal.timeZone = TimeZone(identifier: "Asia/Ho_Chi_Minh") ?? .current
-        let comps = cal.dateComponents([.year, .month, .day], from: date)
+        return cal
+    }()
+
+    private static func lunarOverride(for date: Date) -> (day: Int, month: Int, year: Int)? {
+        let comps = hcmCalendar.dateComponents([.year, .month, .day], from: date)
         guard let y = comps.year, let m = comps.month, let d = comps.day else { return nil }
         return lunarOverrides["\(y)-\(m)-\(d)"]
     }
@@ -117,7 +124,7 @@ struct LunarCalendar {
         // one solar day too early. Skip the extra pod calls otherwise.
         guard raw.day == 1 else { return raw }
 
-        let cal = Calendar(identifier: .gregorian)
+        let cal = hcmCalendar
         guard let nextSolar = cal.date(byAdding: .day, value: 1, to: date),
               let next = VietnameseCalendar(date: nextSolar).vietnameseDate,
               next.day == raw.day, next.month == raw.month

--- a/lich-plus/Features/Calendar/Models/LunarCalendar.swift
+++ b/lich-plus/Features/Calendar/Models/LunarCalendar.swift
@@ -70,18 +70,23 @@ struct LunarCalendar {
         let raw = (day: lunarDate.day, month: lunarDate.month, year: year)
 
         // The underlying pod (VietnameseLunar / Hồ Ngọc Đức algorithm) has a
-        // floor-rounding artifact near GMT+7-midnight new-moon boundaries that
-        // produces off-by-one lunar days for certain solar dates (e.g.
-        // 2026-04-16). Apply hard overrides for known cases, then a generic
-        // repair pass.
+        // floor-rounding artifact near GMT+7-midnight new-moon boundaries.
+        // Apply hard overrides for known buggy dates first, then a generic
+        // duplicate-pair repair pass for the recoverable variant.
         if let override = lunarOverride(for: date) {
             return override
         }
         return repairOffByOneIfNeeded(date: date, raw: raw)
     }
 
-    /// Known off-by-one dates returned by the VietnameseLunar pod. Keyed by
-    /// "YYYY-M-D" (no zero padding) interpreted in Asia/Ho_Chi_Minh.
+    /// Known off-by-one dates returned by the VietnameseLunar pod that the
+    /// generic heuristic cannot recover (typically the clean-shift variant
+    /// where the pod's `k` flips mid-month and no consecutive duplicate is
+    /// produced). Keyed by "YYYY-M-D" (no zero padding) in Asia/Ho_Chi_Minh.
+    ///
+    /// `2026-4-16` is also fixable by the duplicate-pair heuristic below;
+    /// it stays here as documented belt-and-suspenders for the original
+    /// reported bug.
     private static let lunarOverrides: [String: (day: Int, month: Int, year: Int)] = [
         "2026-4-16": (29, 2, 2026)
     ]
@@ -94,48 +99,36 @@ struct LunarCalendar {
         return lunarOverrides["\(y)-\(m)-\(d)"]
     }
 
-    /// Detect and repair the pod's off-by-one where two consecutive solar days
-    /// return the same lunar (day, month) tuple. A correct lunar calendar can
-    /// never produce that, so we treat it as a fingerprint of the bug.
+    /// Repair the pod's "duplicate-pair" off-by-one: two consecutive solar
+    /// days returning the same lunar (d, m, y). A correct lunar calendar can
+    /// never produce that, so when `pod(date) == pod(date+1)`, `date` is the
+    /// buggy one and its correct lunar day is `pod(date-1).day + 1`.
     ///
-    /// In the observed case (Apr 2026): pod returns 28/2, 1/3, 1/3, 2/3 for
-    /// solar Apr 15–18, skipping 29/2. The DUPLICATE pair is (Apr 16, Apr 17)
-    /// and the BUGGY day is the EARLIER one (Apr 16). So we look FORWARD: if
-    /// pod(date) == pod(date+1), then `date` is the off-by-one and the
-    /// correct lunar day is pod(date-1).day + 1.
+    /// Observed at 2026-04-16 (Bính Ngọ M2→M3 new moon). Does NOT cover the
+    /// clean-shift variant (e.g. April 2027/2029/2030) where the pod skips a
+    /// day without leaving a duplicate fingerprint — those need explicit
+    /// overrides or an algorithmic patch (out of scope for this fix; see
+    /// `.claude/backlogs/lunar-apr-2026-off-by-one-plan.md`).
     private static func repairOffByOneIfNeeded(
         date: Date,
         raw: (day: Int, month: Int, year: Int)
     ) -> (day: Int, month: Int, year: Int) {
-        // Fast path: this bug class always manifests as the pod returning day=1
-        // one solar day too early (then repeating it on the legitimate day-1
-        // solar). If raw.day != 1, this date cannot be the duplicate-pair's
-        // earlier (buggy) member, so skip the extra pod calls.
+        // Fast path: this variant always manifests as the pod returning day=1
+        // one solar day too early. Skip the extra pod calls otherwise.
         guard raw.day == 1 else { return raw }
 
         let cal = Calendar(identifier: .gregorian)
         guard let nextSolar = cal.date(byAdding: .day, value: 1, to: date),
-              let next = VietnameseCalendar(date: nextSolar).vietnameseDate
+              let next = VietnameseCalendar(date: nextSolar).vietnameseDate,
+              next.day == raw.day, next.month == raw.month
         else { return raw }
-
-        // Only the duplicate-with-next pattern indicates `date` is the buggy one.
-        guard next.day == raw.day && next.month == raw.month else {
-            return raw
-        }
 
         guard let prevSolar = cal.date(byAdding: .day, value: -1, to: date),
               let prev = VietnameseCalendar(date: prevSolar).vietnameseDate
         else { return raw }
 
         let candidate = prev.day + 1
-        // Lunar months are 29 or 30 days. If incrementing would overflow,
-        // bail out conservatively and trust the pod's raw value (the override
-        // table can catch any cross-month edge case).
         guard candidate <= 30 else { return raw }
-
-        // Use the prior day's (month, year) — they should already match `raw`'s
-        // month in this duplicate-pair case, but anchoring on `prev` avoids
-        // any year-boundary pitfall.
         return (day: candidate, month: prev.month, year: raw.year)
     }
 

--- a/lich-plus/Features/Calendar/Models/LunarCalendar.swift
+++ b/lich-plus/Features/Calendar/Models/LunarCalendar.swift
@@ -129,7 +129,16 @@ struct LunarCalendar {
 
         let candidate = prev.day + 1
         guard candidate <= 30 else { return raw }
-        return (day: candidate, month: prev.month, year: raw.year)
+        // Resolve prev's Int year independently — `raw.year` reflects the
+        // pod's (buggy) day, which at a lunar year boundary can land in the
+        // wrong year. `prev` is mid-month and safe to trust.
+        let prevSolarYear = cal.component(.year, from: prevSolar)
+        let prevYear = resolveLunarYear(
+            solarYear: prevSolarYear,
+            libraryCan: prev.can,
+            libraryChi: prev.chi
+        )
+        return (day: candidate, month: prev.month, year: prevYear)
     }
 
     private static func resolveLunarYear(solarYear: Int, libraryCan: String, libraryChi: String) -> Int {

--- a/lich-plusTests/LunarApr2026BugTests.swift
+++ b/lich-plusTests/LunarApr2026BugTests.swift
@@ -1,0 +1,55 @@
+//
+//  LunarApr2026BugTests.swift
+//  lich-plusTests
+//
+//  Diagnostic test for reported bug: solar 16/04/2026 should be lunar 29/02/2026
+//  but the app displays lunar 01/03/2026.
+//
+
+import XCTest
+@testable import lich_plus
+
+final class LunarApr2026BugTests: XCTestCase {
+
+    private func makeSolar(_ year: Int, _ month: Int, _ day: Int) -> Date {
+        var comps = DateComponents()
+        comps.year = year
+        comps.month = month
+        comps.day = day
+        comps.hour = 12
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "Asia/Ho_Chi_Minh") ?? TimeZone.current
+        return cal.date(from: comps)!
+    }
+
+    func test_solar_16_04_2026_should_be_lunar_29_02_2026() {
+        let date = makeSolar(2026, 4, 16)
+        let lunar = LunarCalendar.solarToLunar(date)
+        XCTAssertEqual(lunar.day, 29, "Expected lunar day 29, got \(lunar.day)")
+        XCTAssertEqual(lunar.month, 2, "Expected lunar month 2, got \(lunar.month)")
+        XCTAssertEqual(lunar.year, 2026, "Expected lunar year 2026, got \(lunar.year)")
+    }
+
+    func test_neighbor_dates_around_apr_2026_lunar_boundary() {
+        // Expected mapping (solar -> lunar) based on standard Hồ Ngọc Đức tables:
+        //   2026-04-15 -> 28/02/2026
+        //   2026-04-16 -> 29/02/2026   <-- bug case
+        //   2026-04-17 -> 01/03/2026
+        //   2026-04-18 -> 02/03/2026
+        let cases: [(Int, Int, Int, Int, Int)] = [
+            (15, 28, 2, 2026, 4),
+            (16, 29, 2, 2026, 4),
+            (17, 1, 3, 2026, 4),
+            (18, 2, 3, 2026, 4),
+        ]
+
+        for (solarDay, expDay, expMonth, expYear, solarMonth) in cases {
+            let d = makeSolar(2026, solarMonth, solarDay)
+            let l = LunarCalendar.solarToLunar(d)
+            print("solar 2026-\(solarMonth)-\(solarDay) -> lunar \(l.day)/\(l.month)/\(l.year)")
+            XCTAssertEqual(l.day, expDay, "day mismatch on solar 2026-04-\(solarDay)")
+            XCTAssertEqual(l.month, expMonth, "month mismatch on solar 2026-04-\(solarDay)")
+            XCTAssertEqual(l.year, expYear, "year mismatch on solar 2026-04-\(solarDay)")
+        }
+    }
+}

--- a/lich-plusTests/LunarBoundarySweepTests.swift
+++ b/lich-plusTests/LunarBoundarySweepTests.swift
@@ -1,0 +1,126 @@
+//
+//  LunarBoundarySweepTests.swift
+//  lich-plusTests
+//
+//  Curated regression mappings for `LunarCalendar.solarToLunar`. Anchors
+//  Tết dates 2024–2028, the original Apr 2026 bug, a couple of mid-month
+//  sanity dates the pod handles correctly, and confirms two known legitimate
+//  leap-month boundaries are passed through (the pod represents these as
+//  same-numeric-month with day rolling 29 → 1).
+//
+//  Out-of-scope pod bugs surfaced during development (clean-shift variants
+//  in Apr 2027, Apr 2029, Apr 2030 where lunar month 2 ends on day 28 with
+//  no consecutive duplicate to detect) are intentionally NOT asserted here.
+//  See `.claude/backlogs/lunar-apr-2026-off-by-one-plan.md` Investigation
+//  Log for tracking.
+//
+
+import XCTest
+@testable import lich_plus
+
+final class LunarBoundarySweepTests: XCTestCase {
+
+    private static let vietnamCalendar: Calendar = {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "Asia/Ho_Chi_Minh") ?? .current
+        return cal
+    }()
+
+    private func makeSolar(_ year: Int, _ month: Int, _ day: Int) -> Date {
+        var comps = DateComponents()
+        comps.year = year
+        comps.month = month
+        comps.day = day
+        comps.hour = 12
+        return Self.vietnamCalendar.date(from: comps)!
+    }
+
+    // MARK: - Tết Nguyên Đán anchors (lunar 1/1 of each year)
+
+    func test_tet_2024_through_2028() {
+        // Tết = lunar new year (lunar 1/1) per Hồ Ngọc Đức tables.
+        let cases: [(sy: Int, sm: Int, sd: Int, ly: Int)] = [
+            (2024, 2, 10, 2024), // Giáp Thìn
+            (2025, 1, 29, 2025), // Ất Tỵ
+            (2026, 2, 17, 2026), // Bính Ngọ
+            (2027, 2,  6, 2027), // Đinh Mùi
+            (2028, 1, 26, 2028)  // Mậu Thân
+        ]
+
+        for c in cases {
+            let l = LunarCalendar.solarToLunar(makeSolar(c.sy, c.sm, c.sd))
+            XCTAssertEqual(l.day, 1, "Tết \(c.ly): wrong lunar day")
+            XCTAssertEqual(l.month, 1, "Tết \(c.ly): wrong lunar month")
+            XCTAssertEqual(l.year, c.ly, "Tết \(c.ly): wrong lunar year")
+        }
+    }
+
+    // MARK: - Apr 2026 boundary (the original bug)
+
+    func test_apr_2026_boundary_pinned() {
+        let cases: [(sd: Int, ld: Int, lm: Int)] = [
+            (15, 28, 2),
+            (16, 29, 2),   // the reported bug
+            (17,  1, 3),
+            (18,  2, 3)
+        ]
+        for c in cases {
+            let l = LunarCalendar.solarToLunar(makeSolar(2026, 4, c.sd))
+            XCTAssertEqual(l.day, c.ld, "solar 2026-04-\(c.sd) lunar day")
+            XCTAssertEqual(l.month, c.lm, "solar 2026-04-\(c.sd) lunar month")
+            XCTAssertEqual(l.year, 2026, "solar 2026-04-\(c.sd) lunar year")
+        }
+    }
+
+    // MARK: - Mid-month sanity (well clear of new-moon boundaries)
+
+    func test_mid_month_sanity_anchors() {
+        // Mid-month dates that should be unaffected by the new-moon
+        // boundary bug class. These prove the wrapper layer doesn't regress
+        // non-boundary conversions.
+        //
+        //   2026-03-04 = Tết + 15 = 15/1/2026 (rằm tháng giêng Bính Ngọ)
+        //   2025-02-12 = Tết + 14 = 15/1/2025 (rằm tháng giêng Ất Tỵ)
+        //   2024-02-24 = Tết + 14 = 15/1/2024 (rằm tháng giêng Giáp Thìn)
+        let cases: [(sy: Int, sm: Int, sd: Int, ld: Int, lm: Int, ly: Int)] = [
+            (2024, 2, 24, 15, 1, 2024),
+            (2025, 2, 12, 15, 1, 2025),
+            (2026, 3,  3, 15, 1, 2026)
+        ]
+        for c in cases {
+            let l = LunarCalendar.solarToLunar(makeSolar(c.sy, c.sm, c.sd))
+            XCTAssertEqual(l.day, c.ld, "solar \(c.sy)-\(c.sm)-\(c.sd) lunar day")
+            XCTAssertEqual(l.month, c.lm, "solar \(c.sy)-\(c.sm)-\(c.sd) lunar month")
+            XCTAssertEqual(l.year, c.ly, "solar \(c.sy)-\(c.sm)-\(c.sd) lunar year")
+        }
+    }
+
+    // MARK: - Duplicate-pair invariant (year-boundary, narrow window)
+
+    /// Verifies that across the 2025-12 → 2026-12 window — covering the
+    /// reported Apr 2026 bug and Tết 2026 — no two consecutive solar days
+    /// map to the same lunar (d, m, y). This is the bug fingerprint the
+    /// duplicate-pair heuristic eliminates; if it ever reappears in this
+    /// window the test fails.
+    func test_no_consecutive_duplicates_in_bich_ngo_2026_window() {
+        let start = makeSolar(2025, 12, 1)
+        let end = makeSolar(2026, 12, 31)
+
+        var current = start
+        var prev = LunarCalendar.solarToLunar(current)
+
+        while current < end {
+            guard let next = Self.vietnamCalendar.date(byAdding: .day, value: 1, to: current) else {
+                XCTFail("Failed to advance from \(current)")
+                return
+            }
+            current = next
+            let now = LunarCalendar.solarToLunar(current)
+            XCTAssertFalse(
+                now.day == prev.day && now.month == prev.month && now.year == prev.year,
+                "Duplicate lunar \(now) on consecutive solar days ending at \(current)"
+            )
+            prev = now
+        }
+    }
+}


### PR DESCRIPTION
## Problem
Solar 16/04/2026 displayed as lunar **1/3/2026** instead of the correct **29/2/2026**. Root cause is a floor-rounding artifact in the VietnameseLunar pod's Hồ Ngọc Đức implementation near GMT+7-midnight new-moon boundaries, which makes two consecutive solar days map to the same lunar (d, m, y).

## Solution
Add a thin wrapper around the pod inside `LunarCalendar.solarToLunar`:

1. **Hard override map** for the original reported date (`2026-04-16 → 29/2/2026`) as a documented belt-and-suspenders entry.
2. **Generic duplicate-pair repair** (`repairOffByOneIfNeeded`): when the pod returns `day == 1` AND the next solar day yields the same `(day, month)`, the current day is the buggy one — recompute as `prev.day + 1` in `prev.month`, with `prev.year` resolved via the existing Can-Chi pipeline so a year-boundary duplicate-pair would not land in the wrong lunar year.
3. Scope limited to the recoverable variant. Clean-shift variants (e.g. some Apr 2027/2029/2030 dates the pod skips without a duplicate fingerprint) are intentionally out of scope and tracked in the backlog plan.

## Impact
- 16/04/2026 now displays the correct lunar date `29/2`.
- No behavior change for any solar date the pod already returned correctly (fast path: only triggers when `raw.day == 1` and the next solar day duplicates the pair).
- No pod fork or upstream patch; isolated wrapper inside the existing converter.

## Testing
New XCTest suites, all 6 tests passing locally on iPhone 17 Pro Max simulator:

- `LunarApr2026BugTests` — pinpoints solar 2026-04-16 → 29/2/2026 and the ±1 neighbors.
- `LunarBoundarySweepTests`:
  - Tết anchors 2024–2028 (Giáp Thìn → Mậu Thân).
  - Apr 2026 boundary pinned.
  - Mid-month rằm anchors (regression guard for non-boundary conversions).
  - Duplicate-pair invariant sweep across 2025-12 → 2026-12 (would re-fail if the pod bug fingerprint reappeared in this window).

Pre-PR review caught a year-boundary defect (returning `raw.year` while sourcing month from `prev` could emit the wrong year at a hypothetical Tết duplicate-pair) — fixed by resolving `prev`'s year through `resolveLunarYear` in commit `a960109`.