### PR TITLE
fix(tests): resolve unit test failures and crashes

### DIFF
--- a/lich-plus.xcodeproj/project.pbxproj
+++ b/lich-plus.xcodeproj/project.pbxproj
@@ -58,8 +58,6 @@
 		};
 		4DA45EE82ED1090100C1F1F6 /* lich-plusTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = "lich-plusTests";
 			sourceTree = "<group>";
 		};
@@ -290,9 +288,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-lich-plus/Pods-lich-plus-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-lich-plus/Pods-lich-plus-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -473,6 +475,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -513,6 +516,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -539,8 +543,9 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = WVYA86B7LC;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.qtran.lich-plusTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -561,8 +566,9 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = WVYA86B7LC;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.qtran.lich-plusTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/lich-plus/Core/Services/CalendarSyncService.swift
+++ b/lich-plus/Core/Services/CalendarSyncService.swift
@@ -64,6 +64,7 @@ final class CalendarSyncService: ObservableObject {
 
     private let eventKitService: EventKitService
     private let modelContext: ModelContext
+    private let userDefaults: UserDefaults
     private var changeObserver: NSObjectProtocol?
 
     // Constants for sync
@@ -83,12 +84,17 @@ final class CalendarSyncService: ObservableObject {
 
     // MARK: - Initialization
 
-    init(eventKitService: EventKitService, modelContext: ModelContext) {
+    init(
+        eventKitService: EventKitService,
+        modelContext: ModelContext,
+        userDefaults: UserDefaults = .standard
+    ) {
         self.eventKitService = eventKitService
         self.modelContext = modelContext
+        self.userDefaults = userDefaults
 
         // Load lastSyncDate from UserDefaults
-        if let savedDate = UserDefaults.standard.object(forKey: userDefaultsLastSyncKey) as? Date {
+        if let savedDate = userDefaults.object(forKey: userDefaultsLastSyncKey) as? Date {
             self.lastSyncDate = savedDate
         }
     }
@@ -120,7 +126,7 @@ final class CalendarSyncService: ObservableObject {
             // Update last sync date
             let now = Date()
             lastSyncDate = now
-            UserDefaults.standard.set(now, forKey: userDefaultsLastSyncKey)
+            userDefaults.set(now, forKey: userDefaultsLastSyncKey)
 
             // Update calendar sync dates
             let enabledCalendars = try getEnabledCalendars()

--- a/lich-plus/Core/Services/NotificationService.swift
+++ b/lich-plus/Core/Services/NotificationService.swift
@@ -189,8 +189,13 @@ final class NotificationService: ObservableObject {
             // Move to next month
             currentDate = calendar.date(byAdding: .month, value: 1, to: currentDate) ?? currentDate
         }
-        
-        return dates.sorted()
+
+        // Dedupe: iterating by solar month can revisit the same lunar month
+        // (lunar months are ~29.5 days, and the leap-month branch can also
+        // produce a date already added in a previous iteration).
+        var seen = Set<TimeInterval>()
+        let unique = dates.filter { seen.insert($0.timeIntervalSince1970).inserted }
+        return unique.sorted()
     }
     
     // MARK: - Rằm Notifications

--- a/lich-plus/Core/Services/NotificationService.swift
+++ b/lich-plus/Core/Services/NotificationService.swift
@@ -193,9 +193,7 @@ final class NotificationService: ObservableObject {
         // Dedupe: iterating by solar month can revisit the same lunar month
         // (lunar months are ~29.5 days, and the leap-month branch can also
         // produce a date already added in a previous iteration).
-        var seen = Set<TimeInterval>()
-        let unique = dates.filter { seen.insert($0.timeIntervalSince1970).inserted }
-        return unique.sorted()
+        return Set(dates).sorted()
     }
     
     // MARK: - Rằm Notifications

--- a/lich-plus/Features/Timeline/Gestures/DragToCreateGesture.swift
+++ b/lich-plus/Features/Timeline/Gestures/DragToCreateGesture.swift
@@ -221,7 +221,14 @@ struct DragPreviewBlock: View {
 // MARK: - Helper Classes for Time Snapping
 
 /// Helper for snapping times to 15-minute grid intervals.
-class DragToCreateSnapHelper {
+//
+// Intentionally a value type: with SWIFT_DEFAULT_ACTOR_ISOLATION=MainActor a
+// `class` here gets an implicit MainActor-isolated deinit, which routes through
+// `swift_task_deinitOnExecutorImpl`. That path hits a libswift_Concurrency bug
+// (TaskLocal::StopLookupScope destructor double-frees) when the deinit runs off
+// the main thread — reproducibly aborts xctest with `pointer being freed was
+// not allocated`. A struct avoids the executor hop entirely.
+struct DragToCreateSnapHelper {
     private let calendar: Calendar
 
     init(calendar: Calendar = .current) {

--- a/lich-plus/Features/Timeline/Gestures/EventInteractionGesture.swift
+++ b/lich-plus/Features/Timeline/Gestures/EventInteractionGesture.swift
@@ -18,7 +18,12 @@ enum SwipeAction: String, CaseIterable, Identifiable {
 /// Manages gesture detection, swipe translations, and offset calculations for
 /// delete and complete actions. Provides haptic feedback and animations for
 /// a polished user experience.
-final class EventInteractionGestureHandler {
+// Value type: with SWIFT_DEFAULT_ACTOR_ISOLATION=MainActor a class here gets an
+// implicit MainActor-isolated deinit, which routes through
+// swift_task_deinitOnExecutorImpl and trips a libswift_Concurrency
+// double-free (TaskLocal::StopLookupScope destructor) when deinit runs off the
+// main thread. A struct avoids the executor hop.
+struct EventInteractionGestureHandler {
 
     // MARK: - Constants
 

--- a/lich-plus/Features/Timeline/Gestures/TimeScaleGesture.swift
+++ b/lich-plus/Features/Timeline/Gestures/TimeScaleGesture.swift
@@ -5,7 +5,12 @@ import SwiftUI
 /// Manages scaling calculations, clamping to valid ranges, and snapping to predefined
 /// scale levels. The three scale levels (15-min, 30-min, 1-hour) correspond to
 /// hour heights of 120pt, 60pt, and 40pt respectively.
-final class TimeScaleGestureHandler {
+// Value type: with SWIFT_DEFAULT_ACTOR_ISOLATION=MainActor a class here gets an
+// implicit MainActor-isolated deinit, which routes through
+// swift_task_deinitOnExecutorImpl and trips a libswift_Concurrency
+// double-free (TaskLocal::StopLookupScope destructor) when deinit runs off the
+// main thread. A struct avoids the executor hop.
+struct TimeScaleGestureHandler {
 
     // MARK: - Constants
 

--- a/lich-plusTests/CalendarSyncServiceTests.swift
+++ b/lich-plusTests/CalendarSyncServiceTests.swift
@@ -16,6 +16,8 @@ final class CalendarSyncServiceTests: XCTestCase {
     var sut: CalendarSyncService!
     var mockEventKitService: MockEventKitService!
     var modelContext: ModelContext!
+    var testDefaults: UserDefaults!
+    var testDefaultsSuiteName: String!
 
     override func setUp() async throws {
         try await super.setUp()
@@ -25,13 +27,20 @@ final class CalendarSyncServiceTests: XCTestCase {
         let container = try ModelContainer(for: SyncableEvent.self, SyncedCalendar.self, configurations: config)
         modelContext = ModelContext(container)
 
+        // Isolated UserDefaults per test — avoid polluting `.standard`,
+        // which is global shared state and can cause flaky behavior and
+        // unrelated allocator issues when reused across tests.
+        testDefaultsSuiteName = "CalendarSyncServiceTests.\(UUID().uuidString)"
+        testDefaults = UserDefaults(suiteName: testDefaultsSuiteName)
+
         // Initialize mock EventKitService
         mockEventKitService = MockEventKitService()
 
         // Initialize SUT
         sut = CalendarSyncService(
             eventKitService: mockEventKitService,
-            modelContext: modelContext
+            modelContext: modelContext,
+            userDefaults: testDefaults
         )
     }
 
@@ -39,6 +48,9 @@ final class CalendarSyncServiceTests: XCTestCase {
         sut = nil
         mockEventKitService = nil
         modelContext = nil
+        testDefaults?.removePersistentDomain(forName: testDefaultsSuiteName)
+        testDefaults = nil
+        testDefaultsSuiteName = nil
         try await super.tearDown()
     }
 
@@ -52,26 +64,19 @@ final class CalendarSyncServiceTests: XCTestCase {
         XCTAssertNil(sut.syncError)
     }
 
-    func testInitializationSetsLastSyncDateFromUserDefaults() throws {
+    func testInitializationSetsLastSyncDateFromUserDefaults() async throws {
         let testDate = Date().addingTimeInterval(-3600) // 1 hour ago
-        UserDefaults.standard.set(testDate, forKey: "CalendarSyncLastSyncDate")
+        testDefaults.set(testDate, forKey: "CalendarSyncLastSyncDate")
 
-        // Reuse the setUp-provided modelContext. Creating a second in-memory
-        // ModelContainer for the same @Model types while the first is still
-        // alive can corrupt SwiftData's allocator state on deinit (manifests
-        // as `pointer being freed was not allocated` in
-        // CalendarSyncService.__deallocating_deinit).
         let testService = CalendarSyncService(
             eventKitService: mockEventKitService,
-            modelContext: modelContext
+            modelContext: modelContext,
+            userDefaults: testDefaults
         )
 
         // Allow small time difference due to initialization
         let timeDiff = abs(testService.lastSyncDate?.timeIntervalSince(testDate) ?? 0)
         XCTAssertLessThan(timeDiff, 1.0)
-
-        // Cleanup
-        UserDefaults.standard.removeObject(forKey: "CalendarSyncLastSyncDate")
     }
 
     // MARK: - Pull Sync Tests

--- a/lich-plusTests/GreetingModelsTests.swift
+++ b/lich-plusTests/GreetingModelsTests.swift
@@ -16,13 +16,13 @@ final class GreetingModelsTests: XCTestCase {
 
     func testRecipientTypeDisplayNames() {
         XCTAssertEqual(RecipientType.grandparents.displayName, "Ông bà")
-        XCTAssertEqual(RecipientType.parents.displayName, "Bố mẹ")
+        XCTAssertEqual(RecipientType.parents.displayName, "Cha mẹ")
         XCTAssertEqual(RecipientType.boss.displayName, "Sếp")
         XCTAssertEqual(RecipientType.colleagues.displayName, "Đồng nghiệp")
-        XCTAssertEqual(RecipientType.teachers.displayName, "Thầy cô")
+        XCTAssertEqual(RecipientType.teachers.displayName, "Giáo viên")
         XCTAssertEqual(RecipientType.friends.displayName, "Bạn bè")
-        XCTAssertEqual(RecipientType.partner.displayName, "Người yêu")
-        XCTAssertEqual(RecipientType.children.displayName, "Con cháu")
+        XCTAssertEqual(RecipientType.partner.displayName, "Vợ chồng")
+        XCTAssertEqual(RecipientType.children.displayName, "Con cái")
     }
 
     func testRecipientTypeIcons() {

--- a/lich-plusTests/GreetingServiceTests.swift
+++ b/lich-plusTests/GreetingServiceTests.swift
@@ -214,12 +214,12 @@ final class GreetingServiceTests: XCTestCase {
 
         let serverError = GreetingServiceError.serverError("Server down")
         XCTAssertNotNil(serverError.errorDescription)
-        XCTAssertTrue(serverError.errorDescription?.contains("Lỗi server") ?? false)
+        XCTAssertTrue(serverError.errorDescription?.contains("Lỗi máy chủ") ?? false)
         XCTAssertTrue(serverError.errorDescription?.contains("Server down") ?? false)
 
         let unauthorized = GreetingServiceError.unauthorized
         XCTAssertNotNil(unauthorized.errorDescription)
-        XCTAssertEqual(unauthorized.errorDescription, "Không có quyền truy cập")
+        XCTAssertEqual(unauthorized.errorDescription, "Truy cập bị từ chối")
     }
 
     // MARK: - Configuration Tests


### PR DESCRIPTION
## Problem
Unit tests had four failures and one crash class:

- `NotificationServiceTests.testGetUpcomingMung1Dates_returnsCorrectDates` / `testGetUpcomingRamDates_returnsCorrectDates` — sorted-order assertions failed because the date list contained duplicates.
- `GreetingModelsTests.testRecipientTypeDisplayNames` — assertions diverged from `Localizable.xcstrings`.
- `GreetingServiceTests.testGreetingServiceError_ErrorDescriptions` — assertions diverged from the catalog (`Lỗi server` vs `Lỗi máy chủ`, `Không có quyền truy cập` vs `Truy cập bị từ chối`).
- Intermittent xctest abort `pointer being freed was not allocated` originating in deinits of `final class` gesture helpers under `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` (libswift_Concurrency double-free in `swift_task_deinitOnExecutorImpl`).

## Solution
- **`NotificationService.getUpcomingLunarDates`** — dedupe before returning. Iterating by solar month combined with the leap-month branch could revisit the same lunar date.
- **`CalendarSyncService`** — accept an injected `UserDefaults` (default `.standard`) so tests can use an isolated suite instead of polluting `.standard`.
- **Timeline gesture helpers** — convert `DragToCreateSnapHelper`, `EventInteractionGestureHandler`, and `TimeScaleGestureHandler` from `final class` to `struct`. With `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, a class gets an implicit MainActor-isolated deinit that routes through `swift_task_deinitOnExecutorImpl` and trips a libswift_Concurrency double-free when run off the main thread. Value types avoid the executor hop entirely; these helpers are pure value-type calculators with no shared state.
- **Test alignment** — update `GreetingModelsTests` and `GreetingServiceTests` expectations to match `Localizable.xcstrings` (catalog is source of truth per CLAUDE.md).
- **Xcode project** — bump test-target deployment target to 18.6 (matching the app target) and add the missing `DEVELOPMENT_TEAM`.

## Impact
- Unit test suite is green: 798/798 passing.
- Eliminates the off-main-thread deinit crash class for the three gesture helpers.
- Test runs no longer mutate `UserDefaults.standard`.
- No runtime behavior change for end users (dedupe only removes duplicates; notification scheduling already used the same `Set`-of-identifier logic downstream).

## Testing
- `run_tests.sh unit` — 798 passed, 0 failed on iPhone 17 Pro (iOS 26.1).
- Diff reviewed for class→struct safety: all three helpers are stored as `private let` and constructed fresh per call; no reference-identity callers.