### PR TITLE
perf(tasks): fix Tasks-tab freeze when opening the timeline

### DIFF
--- a/lich-plus/Core/Services/LunarOccurrenceGenerator.swift
+++ b/lich-plus/Core/Services/LunarOccurrenceGenerator.swift
@@ -28,143 +28,129 @@ struct LunarOccurrenceGenerator {
         rangeStart: Date,
         rangeEnd: Date
     ) -> [Date] {
-        // Get the master lunar date information
-        let masterLunar = LunarCalendar.solarToLunar(masterStartDate)
-        let targetLunarDay = rule.lunarDay
+        // Algorithmic shape: walk solar dates forward from the master start date once,
+        // testing each day's lunar tuple against the target day (and month, for yearly).
+        // Previous implementation searched lunar→solar 192 times per event, each search
+        // brute-forcing up to 425 days. This rewrite makes the work O(rangeDays) instead
+        // of O(years × 12 × 425), and leans on the cached `solarToLunar`.
 
-        // For yearly recurrence, use the specified month or the master's month
-        // For monthly recurrence, targetLunarMonth is used differently
-        let targetLunarMonth: Int?
+        let masterLunar = LunarCalendar.solarToLunar(masterStartDate)
+        let targetDay = rule.lunarDay
+
+        // Monthly recurrence: any lunar month qualifies (matches prior behavior).
+        // Yearly: must match a specific lunar month — rule.lunarMonth or the master's.
+        let targetMonth: Int?
         if rule.frequency == .yearly {
-            targetLunarMonth = rule.lunarMonth ?? masterLunar.month
+            targetMonth = rule.lunarMonth ?? masterLunar.month
         } else {
-            // For monthly, use the specified month (if any), but the actual processing
-            // will iterate through all 12 months
-            targetLunarMonth = rule.lunarMonth
+            targetMonth = nil
         }
 
-        // Get the master lunar year as starting point
-        let masterLunarYear = masterLunar.year
+        // Walk window: start at the master so interval/occurrenceCount are anchored there
+        // (matches prior semantics); end at min(rangeEnd, rule's endDate) if any.
+        let calendar = Calendar.current
+        let walkStart = masterStartDate
+        var walkEnd = rangeEnd
+        if case .endDate(let endDate) = rule.recurrenceEnd, endDate < walkEnd {
+            walkEnd = endDate
+        }
 
-        // Determine how many years to generate (use wide range to be safe)
-        // Convert master lunar year to approximate solar year for calculation
-        let masterSolarDate = LunarCalendar.lunarToSolar(day: 1, month: 1, year: masterLunarYear)
-        let masterSolarYear = Calendar.current.component(.year, from: masterSolarDate)
-        let endSolarYear = Calendar.current.component(.year, from: rangeEnd)
-        let yearsToGenerate = (endSolarYear - masterSolarYear) + 5
+        // After a match we know the next match is at least ~28 days away (lunar months are
+        // 29–30 days). For yearly, the next match in a different year is ~340+ days away.
+        // For occurrenceCount termination, we can stop the walk once we have enough.
+        let skipAfterMatch = (rule.frequency == .yearly) ? 340 : 28
+        let occurrenceCountLimit: Int? = {
+            if case .occurrenceCount(let count) = rule.recurrenceEnd { return count }
+            return nil
+        }()
 
-        var allOccurrences: [Date] = []
+        var candidates: [(date: Date, year: Int, month: Int)] = []
 
-        // Generate occurrences for each lunar year starting from master lunar year
-        for yearOffset in 0..<yearsToGenerate {
-            let lunarYear = masterLunarYear + yearOffset
+        var current = walkStart
+        while current <= walkEnd {
+            let lunar = LunarCalendar.solarToLunar(current)
+            let dayMatch = lunar.day == targetDay
+            let monthMatch = (targetMonth == nil) || (targetMonth == lunar.month)
 
-            let monthsToProcess: [Int]
-            if rule.frequency == .monthly {
-                monthsToProcess = Array(1...12)
-            } else {
-                // Yearly recurrence - use the target month (which is not nil for yearly)
-                monthsToProcess = [targetLunarMonth ?? masterLunar.month]
-            }
+            if dayMatch && monthMatch {
+                candidates.append((current, lunar.year, lunar.month))
+                var lastMatch = current
 
-            for month in monthsToProcess {
-                // Generate occurrences for this lunar date
-                let occurrencesForMonth = generateOccurrencesForMonth(
-                    day: targetLunarDay,
-                    month: month,
-                    year: lunarYear,
-                    leapMonthBehavior: rule.leapMonthBehavior
-                )
-
-                for occurrence in occurrencesForMonth {
-                    // Check if this date already exists (using same-day comparison)
-                    let isDuplicate = allOccurrences.contains { existing in
-                        Calendar.current.isDate(existing, inSameDayAs: occurrence)
-                    }
-                    if !isDuplicate {
-                        allOccurrences.append(occurrence)
+                // Probe for a leap-month variant: same (year, month, day) reappearing
+                // ~29 or ~30 days later. Two probes are enough to catch it.
+                for offset in [29, 30] {
+                    guard let probe = calendar.date(byAdding: .day, value: offset, to: current),
+                          probe <= walkEnd else { break }
+                    let probeLunar = LunarCalendar.solarToLunar(probe)
+                    if probeLunar.day == targetDay
+                        && probeLunar.month == lunar.month
+                        && probeLunar.year == lunar.year {
+                        candidates.append((probe, probeLunar.year, probeLunar.month))
+                        lastMatch = probe
+                        break
                     }
                 }
+
+                // Cheap termination: if we already have enough candidates to satisfy
+                // occurrenceCount post-interval, stop walking. Worst case overshoot is
+                // small (interval/leap behavior may discard some, so add a buffer).
+                if let limit = occurrenceCountLimit,
+                   candidates.count >= max(limit * rule.interval, limit) + 4 {
+                    break
+                }
+
+                guard let next = calendar.date(byAdding: .day, value: skipAfterMatch, to: lastMatch) else { break }
+                current = next
+            } else {
+                guard let next = calendar.date(byAdding: .day, value: 1, to: current) else { break }
+                current = next
             }
         }
 
-        // Sort occurrences
-        let sortedOccurrences = allOccurrences.sorted()
-
-        // Apply interval
-        var filteredOccurrences = applyInterval(sortedOccurrences, interval: rule.interval)
-
-        // Apply recurrence end
-        if let recurrenceEnd = rule.recurrenceEnd {
-            filteredOccurrences = applyRecurrenceEnd(filteredOccurrences, recurrenceEnd: recurrenceEnd)
+        // Group candidates by (year, month) so we can identify leap variants:
+        // a group with two entries means the month repeats — first is regular, second is leap.
+        var dateGroups: [String: [Date]] = [:]
+        for c in candidates {
+            let key = "\(c.year)-\(c.month)"
+            dateGroups[key, default: []].append(c.date)
         }
 
-        // Filter by date range
-        let finalOccurrences = filteredOccurrences.filter { $0 >= rangeStart && $0 <= rangeEnd }
+        var resolved: [Date] = []
+        resolved.reserveCapacity(candidates.count)
+        for c in candidates {
+            let key = "\(c.year)-\(c.month)"
+            guard let group = dateGroups[key] else { continue }
 
-        // Return sorted final occurrences
-        return finalOccurrences.sorted()
+            if group.count <= 1 {
+                resolved.append(c.date)
+                continue
+            }
+
+            // Group has 2 entries: earliest = regular, latest = leap.
+            let isLeap = (c.date == (group.max() ?? c.date))
+            switch rule.leapMonthBehavior {
+            case .includeLeap:
+                resolved.append(c.date)
+            case .skipLeap:
+                if !isLeap { resolved.append(c.date) }
+            case .leapOnly:
+                if isLeap { resolved.append(c.date) }
+            }
+        }
+
+        let sorted = resolved.sorted()
+
+        // Apply interval (indexed from master — same as before).
+        var filtered = applyInterval(sorted, interval: rule.interval)
+
+        if let recurrenceEnd = rule.recurrenceEnd {
+            filtered = applyRecurrenceEnd(filtered, recurrenceEnd: recurrenceEnd)
+        }
+
+        return filtered.filter { $0 >= rangeStart && $0 <= rangeEnd }.sorted()
     }
 
     // MARK: - Helper Methods
-
-    /// Generate occurrences for a specific lunar month/year combination
-    ///
-    /// - Parameters:
-    ///   - day: Lunar day (1-30)
-    ///   - month: Lunar month (1-12)
-    ///   - year: Lunar year
-    ///   - leapMonthBehavior: How to handle leap months
-    /// - Returns: Array of solar dates for the occurrences
-    private static func generateOccurrencesForMonth(
-        day: Int,
-        month: Int,
-        year: Int,
-        leapMonthBehavior: LeapMonthBehavior
-    ) -> [Date] {
-        var occurrences: [Date] = []
-
-        // Get leap month information for this year
-        // Convert lunar year to solar year for leap month detection
-        let approxSolarDate = LunarCalendar.lunarToSolar(day: 1, month: 1, year: year)
-        let solarYear = Calendar.current.component(.year, from: approxSolarDate)
-        let leapInfo = LunarCalendar.getLeapMonthInfo(forSolarYear: solarYear)
-
-        // Check if this month is the leap month
-        let isLeapMonth = leapInfo.hasLeapMonth && leapInfo.leapMonth == month
-
-        if isLeapMonth {
-            // Handle leap month based on behavior
-            switch leapMonthBehavior {
-            case .includeLeap:
-                // Generate both regular and leap occurrences
-                let regularDate = LunarCalendar.lunarToSolar(day: day, month: month, year: year, isLeapMonth: false)
-                let leapDate = LunarCalendar.lunarToSolar(day: day, month: month, year: year, isLeapMonth: true)
-
-                // Only add if they differ (to avoid duplicates)
-                occurrences.append(regularDate)
-                if leapDate != regularDate {
-                    occurrences.append(leapDate)
-                }
-
-            case .skipLeap:
-                // Only generate regular occurrence
-                let regularDate = LunarCalendar.lunarToSolar(day: day, month: month, year: year, isLeapMonth: false)
-                occurrences.append(regularDate)
-
-            case .leapOnly:
-                // Only generate leap occurrence
-                let leapDate = LunarCalendar.lunarToSolar(day: day, month: month, year: year, isLeapMonth: true)
-                occurrences.append(leapDate)
-            }
-        } else {
-            // Regular month (not a leap month)
-            let date = LunarCalendar.lunarToSolar(day: day, month: month, year: year, isLeapMonth: false)
-            occurrences.append(date)
-        }
-
-        return occurrences
-    }
 
     /// Apply interval to occurrences
     ///

--- a/lich-plus/Core/Services/LunarOccurrenceGenerator.swift
+++ b/lich-plus/Core/Services/LunarOccurrenceGenerator.swift
@@ -109,16 +109,17 @@ struct LunarOccurrenceGenerator {
 
         // Group candidates by (year, month) so we can identify leap variants:
         // a group with two entries means the month repeats — first is regular, second is leap.
-        var dateGroups: [String: [Date]] = [:]
+        // Packed `year * 100 + month` is cheaper than a string key in this hot path.
+        var dateGroups: [Int: [Date]] = [:]
         for c in candidates {
-            let key = "\(c.year)-\(c.month)"
+            let key = c.year * 100 + c.month
             dateGroups[key, default: []].append(c.date)
         }
 
         var resolved: [Date] = []
         resolved.reserveCapacity(candidates.count)
         for c in candidates {
-            let key = "\(c.year)-\(c.month)"
+            let key = c.year * 100 + c.month
             guard let group = dateGroups[key] else { continue }
 
             if group.count <= 1 {
@@ -138,16 +139,17 @@ struct LunarOccurrenceGenerator {
             }
         }
 
-        let sorted = resolved.sorted()
-
-        // Apply interval (indexed from master — same as before).
-        var filtered = applyInterval(sorted, interval: rule.interval)
+        // `resolved` is already in forward order (candidates are appended during
+        // a forward solar walk; applyInterval / applyRecurrenceEnd preserve order;
+        // walkEnd already caps the upper bound), so no extra sorts or rangeEnd
+        // filter are needed.
+        var filtered = applyInterval(resolved, interval: rule.interval)
 
         if let recurrenceEnd = rule.recurrenceEnd {
             filtered = applyRecurrenceEnd(filtered, recurrenceEnd: recurrenceEnd)
         }
 
-        return filtered.filter { $0 >= rangeStart && $0 <= rangeEnd }.sorted()
+        return filtered.filter { $0 >= rangeStart }
     }
 
     // MARK: - Helper Methods

--- a/lich-plus/Features/Calendar/Models/LunarCalendar.swift
+++ b/lich-plus/Features/Calendar/Models/LunarCalendar.swift
@@ -45,12 +45,21 @@ struct LunarCalendar {
     /// Cache for leap month information: solarYear -> LeapMonthInfo
     private static var leapMonthCache: [Int: LeapMonthInfo] = [:]
 
-    /// Maximum cache size before clearing (to prevent unbounded growth)
-    private static let maxCacheSize = 1000
+    /// Maximum cache size before clearing (to prevent unbounded growth).
+    /// Sized to comfortably hold the 6-year production expansion window
+    /// (~2190 solar days) plus some headroom — smaller values caused the
+    /// `solarToLunar` cache to thrash mid-expansion.
+    private static let maxCacheSize = 3000
 
     /// Shared Gregorian calendar — instantiating per call is measurably expensive
     /// inside the lunar conversion hot path.
     private static let gregorianCalendar = Calendar(identifier: .gregorian)
+
+    /// Guards the three static caches against concurrent access. The conversion
+    /// helpers are called from `@MainActor` services today, but they're also
+    /// reachable from background-sync `Task`s and `NotificationService`'s
+    /// scheduling code, so the caches need explicit synchronization.
+    private static let cacheLock = NSLock()
 
     /// Convert solar date to lunar date
     /// - Parameter date: Solar date to convert
@@ -58,12 +67,8 @@ struct LunarCalendar {
     static func solarToLunar(_ date: Date) -> (day: Int, month: Int, year: Int) {
         // Normalize to start-of-day so identical calendar days share a cache entry.
         let dayKey = gregorianCalendar.startOfDay(for: date)
-        if let cached = solarToLunarCache[dayKey] {
+        if let cached = cacheLock.withLock({ solarToLunarCache[dayKey] }) {
             return cached
-        }
-
-        if solarToLunarCache.count > maxCacheSize {
-            solarToLunarCache.removeAll()
         }
 
         // Use an explicit Gregorian calendar — Calendar.current can be set to
@@ -73,7 +78,7 @@ struct LunarCalendar {
         let vietnameseCalendar = VietnameseCalendar(date: date)
         guard let lunarDate = vietnameseCalendar.vietnameseDate else {
             let fallback = (day: 1, month: 1, year: solarYear)
-            solarToLunarCache[dayKey] = fallback
+            storeSolarToLunar(dayKey, fallback)
             return fallback
         }
 
@@ -100,8 +105,17 @@ struct LunarCalendar {
         } else {
             result = repairOffByOneIfNeeded(date: date, raw: raw)
         }
-        solarToLunarCache[dayKey] = result
+        storeSolarToLunar(dayKey, result)
         return result
+    }
+
+    private static func storeSolarToLunar(_ key: Date, _ value: (day: Int, month: Int, year: Int)) {
+        cacheLock.withLock {
+            if solarToLunarCache.count > maxCacheSize {
+                solarToLunarCache.removeAll()
+            }
+            solarToLunarCache[key] = value
+        }
     }
 
     /// Known off-by-one dates returned by the VietnameseLunar pod that the
@@ -265,14 +279,8 @@ struct LunarCalendar {
     /// - Parameter forSolarYear: The solar year to check
     /// - Returns: LeapMonthInfo struct with leap month details
     static func getLeapMonthInfo(forSolarYear solarYear: Int) -> LeapMonthInfo {
-        // Check cache first
-        if let cached = leapMonthCache[solarYear] {
+        if let cached = cacheLock.withLock({ leapMonthCache[solarYear] }) {
             return cached
-        }
-
-        // Clear cache if it gets too large
-        if leapMonthCache.count > maxCacheSize {
-            leapMonthCache.removeAll()
         }
 
         // Strategy: Check all lunar years that span this solar year
@@ -317,7 +325,7 @@ struct LunarCalendar {
                 leapMonth: leapMonth,
                 lunarYear: targetLunarDate.year
             )
-            leapMonthCache[solarYear] = result
+            storeLeapMonth(solarYear, result)
             return result
         }
 
@@ -340,8 +348,17 @@ struct LunarCalendar {
             leapMonth: nil,
             lunarYear: targetLunarDate.year
         )
-        leapMonthCache[solarYear] = result
+        storeLeapMonth(solarYear, result)
         return result
+    }
+
+    private static func storeLeapMonth(_ key: Int, _ value: LeapMonthInfo) {
+        cacheLock.withLock {
+            if leapMonthCache.count > maxCacheSize {
+                leapMonthCache.removeAll()
+            }
+            leapMonthCache[key] = value
+        }
     }
 
     // MARK: - Private Leap Month Detection
@@ -398,15 +415,9 @@ struct LunarCalendar {
     /// Since VietnameseLunar doesn't directly support lunar-to-solar conversion,
     /// we search through dates until we find the matching lunar date
     private static func convertLunarToSolar(lunarDay: Int, lunarMonth: Int, lunarYear: Int) -> (day: Int, month: Int, year: Int) {
-        // Check cache first
         let cacheKey = "\(lunarDay)-\(lunarMonth)-\(lunarYear)"
-        if let cached = lunarToSolarCache[cacheKey] {
+        if let cached = cacheLock.withLock({ lunarToSolarCache[cacheKey] }) {
             return cached
-        }
-
-        // Clear cache if it gets too large
-        if lunarToSolarCache.count > maxCacheSize {
-            lunarToSolarCache.removeAll()
         }
 
         let calendar = Calendar.current
@@ -422,7 +433,7 @@ struct LunarCalendar {
             if lunar.day == lunarDay && lunar.month == lunarMonth && lunar.year == lunarYear {
                 let components = calendar.dateComponents([.year, .month, .day], from: testDate)
                 let result = (day: components.day ?? 1, month: components.month ?? 1, year: components.year ?? lunarYear)
-                lunarToSolarCache[cacheKey] = result
+                storeLunarToSolar(cacheKey, result)
                 return result
             }
             testDate = calendar.date(byAdding: .day, value: 1, to: testDate) ?? testDate
@@ -435,7 +446,7 @@ struct LunarCalendar {
             if lunar.day == lunarDay && lunar.month == lunarMonth && lunar.year == lunarYear {
                 let components = calendar.dateComponents([.year, .month, .day], from: testDate)
                 let result = (day: components.day ?? 1, month: components.month ?? 1, year: components.year ?? lunarYear)
-                lunarToSolarCache[cacheKey] = result
+                storeLunarToSolar(cacheKey, result)
                 return result
             }
             testDate = calendar.date(byAdding: .day, value: 1, to: testDate) ?? testDate
@@ -447,8 +458,17 @@ struct LunarCalendar {
         let estimatedSolarMonth = lunarMonth < 11 ? lunarMonth + 1 : (lunarMonth == 11 ? 12 : 1)
         let estimatedSolarYear = lunarMonth >= 11 ? lunarYear + 1 : lunarYear
         let fallback = (day: min(lunarDay, 28), month: estimatedSolarMonth, year: estimatedSolarYear)
-        lunarToSolarCache[cacheKey] = fallback
+        storeLunarToSolar(cacheKey, fallback)
         return fallback
+    }
+
+    private static func storeLunarToSolar(_ key: String, _ value: (day: Int, month: Int, year: Int)) {
+        cacheLock.withLock {
+            if lunarToSolarCache.count > maxCacheSize {
+                lunarToSolarCache.removeAll()
+            }
+            lunarToSolarCache[key] = value
+        }
     }
 }
 

--- a/lich-plus/Features/Calendar/Models/LunarCalendar.swift
+++ b/lich-plus/Features/Calendar/Models/LunarCalendar.swift
@@ -39,23 +39,42 @@ struct LunarCalendar {
     /// Cache for lunar-to-solar conversions: (day, month, year) -> (day, month, year)
     private static var lunarToSolarCache: [String: (day: Int, month: Int, year: Int)] = [:]
 
+    /// Cache for solar-to-lunar conversions: startOfDay(solarDate) -> (day, month, year)
+    private static var solarToLunarCache: [Date: (day: Int, month: Int, year: Int)] = [:]
+
     /// Cache for leap month information: solarYear -> LeapMonthInfo
     private static var leapMonthCache: [Int: LeapMonthInfo] = [:]
 
     /// Maximum cache size before clearing (to prevent unbounded growth)
     private static let maxCacheSize = 1000
 
+    /// Shared Gregorian calendar — instantiating per call is measurably expensive
+    /// inside the lunar conversion hot path.
+    private static let gregorianCalendar = Calendar(identifier: .gregorian)
+
     /// Convert solar date to lunar date
     /// - Parameter date: Solar date to convert
     /// - Returns: Tuple of (lunarDay, lunarMonth, lunarYear)
     static func solarToLunar(_ date: Date) -> (day: Int, month: Int, year: Int) {
+        // Normalize to start-of-day so identical calendar days share a cache entry.
+        let dayKey = gregorianCalendar.startOfDay(for: date)
+        if let cached = solarToLunarCache[dayKey] {
+            return cached
+        }
+
+        if solarToLunarCache.count > maxCacheSize {
+            solarToLunarCache.removeAll()
+        }
+
         // Use an explicit Gregorian calendar — Calendar.current can be set to
         // a non-Gregorian system (Buddhist, Japanese, ...) on the user's device,
         // which would skew the integer year fed into CanChiCalculator.
-        let solarYear = Calendar(identifier: .gregorian).component(.year, from: date)
+        let solarYear = gregorianCalendar.component(.year, from: date)
         let vietnameseCalendar = VietnameseCalendar(date: date)
         guard let lunarDate = vietnameseCalendar.vietnameseDate else {
-            return (1, 1, solarYear)
+            let fallback = (day: 1, month: 1, year: solarYear)
+            solarToLunarCache[dayKey] = fallback
+            return fallback
         }
 
         // VietnameseLunar exposes `year` as a String formatted "<Can> <Chi>" (e.g. "Bính Ngọ"),
@@ -72,11 +91,17 @@ struct LunarCalendar {
         // The underlying pod (VietnameseLunar / Hồ Ngọc Đức algorithm) has a
         // floor-rounding artifact near GMT+7-midnight new-moon boundaries.
         // Apply hard overrides for known buggy dates first, then a generic
-        // duplicate-pair repair pass for the recoverable variant.
+        // duplicate-pair repair pass for the recoverable variant. Cache the
+        // repaired result so subsequent calls skip both the pod call and the
+        // repair probe.
+        let result: (day: Int, month: Int, year: Int)
         if let override = lunarOverride(for: date) {
-            return override
+            result = override
+        } else {
+            result = repairOffByOneIfNeeded(date: date, raw: raw)
         }
-        return repairOffByOneIfNeeded(date: date, raw: raw)
+        solarToLunarCache[dayKey] = result
+        return result
     }
 
     /// Known off-by-one dates returned by the VietnameseLunar pod that the

--- a/lich-plus/Features/Tasks/TasksView.swift
+++ b/lich-plus/Features/Tasks/TasksView.swift
@@ -33,11 +33,13 @@ struct TasksView: View {
     // MARK: - Computed Properties
 
     private var eventsFingerprint: String {
+        // Sum (not max) of timestamps so an edit to any event invalidates the
+        // fingerprint, not only edits that bump the maximum. Background-sync
+        // writes can arrive with timestamps older than an existing local edit;
+        // a max-only fingerprint would silently skip the rebuild in that case.
         let count = syncableEvents.count
-        let maxUpdated = syncableEvents
-            .map { $0.lastModifiedLocal }
-            .max() ?? .distantPast
-        return "\(count)-\(maxUpdated.timeIntervalSince1970)"
+        let sum = syncableEvents.reduce(0.0) { $0 + $1.lastModifiedLocal.timeIntervalSince1970 }
+        return "\(count)-\(sum)"
     }
 
     private var filteredTasks: [TaskItem] {

--- a/lich-plus/Features/Tasks/TasksView.swift
+++ b/lich-plus/Features/Tasks/TasksView.swift
@@ -26,27 +26,26 @@ struct TasksView: View {
     @State private var showAddSheet: Bool = false
     @State private var addEventDate: Date? = nil
     @State private var editingEvent: SyncableEvent? = nil
-    @State private var refreshCounter: Int = 0
     @State private var showEventNotFoundAlert: Bool = false
     @State private var navigateToDate: Date? = nil
+    @State private var tasks: [TaskItem] = []
 
     // MARK: - Computed Properties
 
-    private var tasks: [TaskItem] {
-        RecurringEventExpander.expandRecurringEvents(syncableEvents)
+    private var eventsFingerprint: String {
+        let count = syncableEvents.count
+        let maxUpdated = syncableEvents
+            .map { $0.lastModifiedLocal }
+            .max() ?? .distantPast
+        return "\(count)-\(maxUpdated.timeIntervalSince1970)"
     }
 
     private var filteredTasks: [TaskItem] {
-        var filtered = tasks
-
-        if !searchText.isEmpty {
-            filtered = filtered.filter { task in
-                task.title.localizedCaseInsensitiveContains(searchText) ||
-                    (task.notes?.localizedCaseInsensitiveContains(searchText) ?? false)
-            }
+        guard !searchText.isEmpty else { return tasks }
+        return tasks.filter { task in
+            task.title.localizedCaseInsensitiveContains(searchText) ||
+                (task.notes?.localizedCaseInsensitiveContains(searchText) ?? false)
         }
-
-        return filtered.sorted { $0.date < $1.date }
     }
 
     /// Events for a given date (used when navigating to Day view)
@@ -91,7 +90,6 @@ struct TasksView: View {
                         navigateToDate = date
                     }
                 )
-                .id(refreshCounter)
             }
             .background(AppColors.background)
             .navigationDestination(item: $navigateToDate) { date in
@@ -109,8 +107,8 @@ struct TasksView: View {
                     onToggleCompletion: toggleTaskCompletion
                 )
             }
-            .onReceive(NotificationCenter.default.publisher(for: .calendarDataDidChange)) { _ in
-                refreshCounter += 1
+            .task(id: eventsFingerprint) {
+                tasks = RecurringEventExpander.expandRecurringEvents(syncableEvents)
             }
             .sheet(isPresented: $showAddSheet) {
                 CreateItemSheet(

--- a/lich-plus/Features/Tasks/Views/InfiniteTimelineView.swift
+++ b/lich-plus/Features/Tasks/Views/InfiniteTimelineView.swift
@@ -122,8 +122,11 @@ struct InfiniteTimelineView: View {
                     guard !hasInitialScrolled else { return }
                     if let anchorID = anchorSectionID {
                         scrollProxy.scrollTo(anchorID, anchor: .top)
-                        hasInitialScrolled = true
                     }
+                    // Flip even when anchorSectionID is nil (empty tasks),
+                    // otherwise the ScrollView's opacity stays at 0 and the
+                    // EmptyStateView is invisible.
+                    hasInitialScrolled = true
                 }
 
                 // Today floating button - shows when anchor section is off-screen
@@ -149,8 +152,7 @@ struct InfiniteTimelineView: View {
                     .transition(.scale.combined(with: .opacity))
             }
             .animation(.easeInOut(duration: 0.2), value: isAnchorSectionVisible)
-            .onAppear { rebuildCache() }
-            .onChange(of: tasks) { _, _ in rebuildCache() }
+            .task(id: tasks) { rebuildCache() }
         }
     }
 }

--- a/lich-plus/Features/Tasks/Views/InfiniteTimelineView.swift
+++ b/lich-plus/Features/Tasks/Views/InfiniteTimelineView.swift
@@ -17,10 +17,22 @@ struct InfiniteTimelineView: View {
 
     @State private var hasInitialScrolled: Bool = false
     @State private var isAnchorSectionVisible: Bool = false
+    @State private var groupedTasks: [(date: Date, items: [TaskItem])] = []
+    @State private var anchorSectionID: String?
 
     var calendar: Calendar = Calendar.current
 
-    private var groupedTasks: [(date: Date, items: [TaskItem])] {
+    private static let dateIDFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyyMMdd"
+        return f
+    }()
+
+    private func dateID(_ date: Date) -> String {
+        Self.dateIDFormatter.string(from: date)
+    }
+
+    private func rebuildCache() {
         var groupedByDate: [Date: [TaskItem]] = [:]
 
         for task in tasks {
@@ -33,31 +45,23 @@ struct InfiniteTimelineView: View {
         }
 
         let sortedDates = groupedByDate.keys.sorted()
-        return sortedDates.map { date in
+        let groups = sortedDates.map { date -> (date: Date, items: [TaskItem]) in
             let dayTasks = (groupedByDate[date] ?? [])
                 .sorted { ($0.startTime ?? $0.date) < ($1.startTime ?? $1.date) }
             return (date: date, items: dayTasks)
         }
-    }
+        groupedTasks = groups
 
-    // Anchor section: today if exists, else nearest future, else first
-    private var anchorSectionID: String? {
         let today = calendar.startOfDay(for: Date())
-
-        if let todayGroup = groupedTasks.first(where: { calendar.isDateInToday($0.date) }) {
-            return dateID(todayGroup.date)
-        } else if let futureGroup = groupedTasks.first(where: { $0.date > today }) {
-            return dateID(futureGroup.date)
-        } else if let firstGroup = groupedTasks.first {
-            return dateID(firstGroup.date)
+        if let todayGroup = groups.first(where: { calendar.isDateInToday($0.date) }) {
+            anchorSectionID = dateID(todayGroup.date)
+        } else if let futureGroup = groups.first(where: { $0.date > today }) {
+            anchorSectionID = dateID(futureGroup.date)
+        } else if let firstGroup = groups.first {
+            anchorSectionID = dateID(firstGroup.date)
+        } else {
+            anchorSectionID = nil
         }
-        return nil
-    }
-
-    private func dateID(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyyMMdd"
-        return formatter.string(from: date)
     }
 
     var body: some View {
@@ -114,11 +118,12 @@ struct InfiniteTimelineView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(AppColors.background)
                 .opacity(hasInitialScrolled ? 1 : 0)
-                .task {
+                .task(id: anchorSectionID) {
+                    guard !hasInitialScrolled else { return }
                     if let anchorID = anchorSectionID {
                         scrollProxy.scrollTo(anchorID, anchor: .top)
+                        hasInitialScrolled = true
                     }
-                    hasInitialScrolled = true
                 }
 
                 // Today floating button - shows when anchor section is off-screen
@@ -144,6 +149,8 @@ struct InfiniteTimelineView: View {
                     .transition(.scale.combined(with: .opacity))
             }
             .animation(.easeInOut(duration: 0.2), value: isAnchorSectionVisible)
+            .onAppear { rebuildCache() }
+            .onChange(of: tasks) { _, _ in rebuildCache() }
         }
     }
 }

--- a/lich-plusTests/LunarOccurrenceGeneratorTests.swift
+++ b/lich-plusTests/LunarOccurrenceGeneratorTests.swift
@@ -480,6 +480,182 @@ final class LunarOccurrenceGeneratorTests: XCTestCase {
         XCTAssertTrue(isSorted)
     }
 
+    // MARK: - Forward-Walk Rewrite Regression Tests
+    // These tests pin behaviors that the forward-solar-walk implementation must
+    // preserve. They use 2023 (a known Vietnamese lunar leap-month-2 year) as a
+    // reference for leap-variant behavior.
+
+    /// "Mùng 1" — monthly recurrence on lunar day 1 over the production 6-year window.
+    /// Asserts that the new generator produces roughly one occurrence per lunar
+    /// month (no missed months, no duplicates beyond legitimate leap variants).
+    func testMonthlyDay1OverSixYearsCountWithinExpectedRange() {
+        let rule = SerializableLunarRecurrenceRule(
+            frequency: .monthly,
+            lunarDay: 1,
+            lunarMonth: nil,
+            leapMonthBehavior: .skipLeap,
+            interval: 1,
+            recurrenceEnd: nil
+        )
+
+        // Span equivalent to the production range: 1 year past + 5 years future.
+        let masterStartDate = Calendar.current.date(from: DateComponents(year: 2025, month: 5, day: 17))!
+        let rangeStart = Calendar.current.date(from: DateComponents(year: 2025, month: 5, day: 17))!
+        let rangeEnd = Calendar.current.date(from: DateComponents(year: 2031, month: 5, day: 17))!
+
+        let occurrences = LunarOccurrenceGenerator.generateOccurrences(
+            rule: rule,
+            masterStartDate: masterStartDate,
+            rangeStart: rangeStart,
+            rangeEnd: rangeEnd
+        )
+
+        // 6 lunar years × 12 months = 72; allow ±2 for window boundaries.
+        // skipLeap means leap-month duplicates are excluded.
+        XCTAssertGreaterThan(occurrences.count, 65, "Expected ~72 monthly occurrences over 6 years")
+        XCTAssertLessThan(occurrences.count, 78)
+
+        // No two occurrences should land on the same calendar day.
+        let uniqueDays = Set(occurrences.map { Calendar.current.startOfDay(for: $0) })
+        XCTAssertEqual(uniqueDays.count, occurrences.count, "Occurrences must be unique by day")
+    }
+
+    /// Leap-month behavior contract (matches pre-rewrite semantics):
+    ///   - For lunar months WITHOUT a leap variant, ALL three behaviors emit
+    ///     the regular occurrence.
+    ///   - For lunar months WITH a leap variant (i.e., the month appears twice
+    ///     in the same lunar year), behaviors diverge:
+    ///       .includeLeap → both regular and leap
+    ///       .skipLeap    → regular only
+    ///       .leapOnly    → leap only
+    /// 2023 has lunar leap month 2, which is the only month-with-leap in the
+    /// year — making it the cleanest cell to assert the contract against.
+    func testLeapMonthBehaviorContractAcross2023() {
+        let masterStartDate = Calendar.current.date(from: DateComponents(year: 2023, month: 1, day: 1))!
+        let rangeStart = masterStartDate
+        let rangeEnd = Calendar.current.date(from: DateComponents(year: 2023, month: 12, day: 31))!
+
+        func run(_ behavior: LeapMonthBehavior) -> [Date] {
+            let rule = SerializableLunarRecurrenceRule(
+                frequency: .monthly,
+                lunarDay: 1,
+                lunarMonth: nil,
+                leapMonthBehavior: behavior,
+                interval: 1,
+                recurrenceEnd: nil
+            )
+            return LunarOccurrenceGenerator.generateOccurrences(
+                rule: rule,
+                masterStartDate: masterStartDate,
+                rangeStart: rangeStart,
+                rangeEnd: rangeEnd
+            )
+        }
+
+        let skip = run(.skipLeap)
+        let include = run(.includeLeap)
+        let leapOnly = run(.leapOnly)
+
+        // includeLeap should contain every regular AND every leap variant —
+        // strictly more dates than skipLeap (by exactly the leap-variant count).
+        XCTAssertGreaterThan(include.count, skip.count,
+                             "includeLeap must contain strictly more occurrences than skipLeap")
+        XCTAssertEqual(include.count - skip.count, 1,
+                       "2023 has exactly one leap month; includeLeap - skipLeap should equal 1")
+
+        // skipLeap and leapOnly emit the same NUMBER of occurrences (one per
+        // lunar month captured): for non-leap months both emit the same
+        // regular date; for the leap month they emit different sides of the pair.
+        XCTAssertEqual(skip.count, leapOnly.count,
+                       "skipLeap and leapOnly produce one entry per captured month")
+
+        // skipLeap and leapOnly should differ on exactly one date — the
+        // leap-month's regular vs leap variant.
+        let skipSet = Set(skip.map { Calendar.current.startOfDay(for: $0) })
+        let leapOnlySet = Set(leapOnly.map { Calendar.current.startOfDay(for: $0) })
+        let symmetricDifference = skipSet.symmetricDifference(leapOnlySet)
+        XCTAssertEqual(symmetricDifference.count, 2,
+                       "skipLeap and leapOnly should differ on exactly the leap month (regular date in one, leap date in the other)")
+
+        // Every skipLeap and leapOnly date must appear in includeLeap.
+        let includeSet = Set(include.map { Calendar.current.startOfDay(for: $0) })
+        XCTAssertTrue(skipSet.isSubset(of: includeSet))
+        XCTAssertTrue(leapOnlySet.isSubset(of: includeSet))
+    }
+
+    /// Yearly recurrence on month 2 with `.leapOnly`: when a year has lunar
+    /// leap month 2 the leap variant is used; when it doesn't, the regular
+    /// month-2 occurrence is still emitted. This matches pre-rewrite behavior.
+    /// Comparing against `.skipLeap` across the same window proves the algorithm
+    /// emits the LEAP date in 2023 specifically.
+    func testYearlyLeapOnlyDiffersFromSkipLeapOnlyInLeapYears() {
+        let masterStartDate = Calendar.current.date(from: DateComponents(year: 2022, month: 1, day: 1))!
+        let rangeStart = masterStartDate
+        let rangeEnd = Calendar.current.date(from: DateComponents(year: 2027, month: 12, day: 31))!
+
+        func run(_ behavior: LeapMonthBehavior) -> [Date] {
+            let rule = SerializableLunarRecurrenceRule(
+                frequency: .yearly,
+                lunarDay: 15,
+                lunarMonth: 2,
+                leapMonthBehavior: behavior,
+                interval: 1,
+                recurrenceEnd: nil
+            )
+            return LunarOccurrenceGenerator.generateOccurrences(
+                rule: rule,
+                masterStartDate: masterStartDate,
+                rangeStart: rangeStart,
+                rangeEnd: rangeEnd
+            )
+        }
+
+        let skip = run(.skipLeap)
+        let leapOnly = run(.leapOnly)
+
+        XCTAssertEqual(skip.count, leapOnly.count,
+                       "skipLeap and leapOnly should yield the same number of yearly occurrences")
+
+        // 2023 is the only leap-month-2 year in the 2022–2027 window, so
+        // exactly one date should differ between the two.
+        let skipSet = Set(skip.map { Calendar.current.startOfDay(for: $0) })
+        let leapOnlySet = Set(leapOnly.map { Calendar.current.startOfDay(for: $0) })
+        let diff = skipSet.symmetricDifference(leapOnlySet)
+        XCTAssertEqual(diff.count, 2, "Exactly one year (2023) should produce different dates between skipLeap and leapOnly")
+    }
+
+    /// Performance guard: expanding monthly day=1 over the production 6-year
+    /// window must complete in well under the freeze threshold the user was hitting.
+    /// First call is cold (cache empty). Threshold chosen to be generous so this
+    /// is a smoke test, not a flaky benchmark.
+    func testMonthlyExpansionPerformanceUnderOneSecond() {
+        let rule = SerializableLunarRecurrenceRule(
+            frequency: .monthly,
+            lunarDay: 1,
+            lunarMonth: nil,
+            leapMonthBehavior: .skipLeap,
+            interval: 1,
+            recurrenceEnd: nil
+        )
+
+        let masterStartDate = Calendar.current.date(from: DateComponents(year: 2025, month: 5, day: 17))!
+        let rangeStart = masterStartDate
+        let rangeEnd = Calendar.current.date(from: DateComponents(year: 2031, month: 5, day: 17))!
+
+        let start = CFAbsoluteTimeGetCurrent()
+        _ = LunarOccurrenceGenerator.generateOccurrences(
+            rule: rule,
+            masterStartDate: masterStartDate,
+            rangeStart: rangeStart,
+            rangeEnd: rangeEnd
+        )
+        let elapsed = CFAbsoluteTimeGetCurrent() - start
+
+        // Old implementation took ~6 seconds per event on this dataset.
+        // The rewrite plus the solarToLunar cache should land well under 1 second.
+        XCTAssertLessThan(elapsed, 1.0, "Monthly expansion took \(elapsed)s — perf regression vs forward-walk rewrite")
+    }
+
     /// Test no duplicates in results
     func testNoDuplicatesInResults() {
         let rule = SerializableLunarRecurrenceRule(


### PR DESCRIPTION
## Problem

Opening the Tasks tab froze the UI for several seconds (up to ~6s on real device data). Two compounding hot paths:

1. `TasksView` recomputed `RecurringEventExpander.expandRecurringEvents(...)` on every body re-render, and `InfiniteTimelineView` regrouped the resulting array on every render too.
2. `LunarOccurrenceGenerator.generateOccurrences` did a lunar→solar search 192 times per lunar recurring event over the 6-year production window, each search brute-forcing up to ~425 candidate days. Each call also re-instantiated a Gregorian `Calendar` and re-converted solar→lunar without memoization.

## Solution

- **Cache the expanded tasks list in `TasksView`** — moved from a computed `var tasks` to `@State tasks` rebuilt via `.task(id: eventsFingerprint)`. Fingerprint = `count + sum(lastModifiedLocal)` so any edit invalidates the cache (not only edits to the newest event).
- **Cache the grouped sections in `InfiniteTimelineView`** — `@State groupedTasks` rebuilt via `.task(id: tasks)`. Hoisted the section-ID `DateFormatter` to a static. Fixed the empty-state path to still flip `hasInitialScrolled` so `EmptyStateView` is visible when there are no tasks.
- **Memoize `LunarCalendar.solarToLunar`** keyed by `startOfDay`, and hoist a shared `Calendar(identifier: .gregorian)` instead of allocating per call.
- **Rewrite `LunarOccurrenceGenerator` as a forward solar walk** — walk solar dates from the master once, test each day's lunar tuple, skip ahead 28d/340d after a match. Leap-month variants detected by probing +29/+30d. Algorithmic shape goes from O(years × 12 × 425) to O(rangeDays) per event, and leans on the new `solarToLunar` cache.

## Impact

- Tasks tab opens without a visible freeze. The performance guard test asserts the production 6-year monthly expansion completes in <1s (was ~6s).
- All pre-existing leap-month behavior preserved: 4 new regression tests pin `.includeLeap` / `.skipLeap` / `.leapOnly` semantics and the count contract over a 6-year window.
- Rebased onto latest `main`, including the lunar off-by-one repair from #52 — the repair runs once per solar day and its result is cached.

## Testing

- New tests in `LunarOccurrenceGeneratorTests`:
  - `testMonthlyDay1OverSixYearsCountWithinExpectedRange` — count + uniqueness over 6 lunar years.
  - `testLeapMonthBehaviorContractAcross2023` — `.includeLeap` ⊋ `.skipLeap`, `.skipLeap` ↔ `.leapOnly` differ on exactly the leap month.
  - `testYearlyLeapOnlyDiffersFromSkipLeapOnlyInLeapYears` — yearly recurrence yields the leap variant in 2023 only.
  - `testMonthlyExpansionPerformanceUnderOneSecond` — perf guard (<1s).
- Clean Debug build passes. Tests run requested to be skipped this round; lunar regression suite (20 tests) passed locally pre-rebase.
- Manually verified Tasks tab opens immediately on the test device with production recurring events.